### PR TITLE
Add Visitor unit tests

### DIFF
--- a/tests/Query/Builders/Visitors/AggregateDetectionVisitorTests.cs
+++ b/tests/Query/Builders/Visitors/AggregateDetectionVisitorTests.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq.Expressions;
+using Kafka.Ksql.Linq.Query.Builders;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Builders.Visitors;
+
+public class AggregateDetectionVisitorTests
+{
+    private static class Agg
+    {
+        public static int Sum(int value) => value;
+    }
+
+    private class Sample
+    {
+        public int Amount { get; set; }
+        public int Value { get; set; }
+    }
+
+    [Fact]
+    public void Visit_WithAggregateMethod_DetectsAggregate()
+    {
+        Expression<Func<Sample, int>> expr = e => e.Amount + Agg.Sum(e.Value);
+        var visitor = new AggregateDetectionVisitor();
+        visitor.Visit(expr.Body);
+        Assert.True(visitor.HasAggregates);
+    }
+
+    [Fact]
+    public void Visit_WithoutAggregateMethod_NoDetection()
+    {
+        Expression<Func<Sample, int>> expr = e => e.Amount + e.Value;
+        var visitor = new AggregateDetectionVisitor();
+        visitor.Visit(expr.Body);
+        Assert.False(visitor.HasAggregates);
+    }
+}

--- a/tests/Query/Builders/Visitors/GroupByExpressionVisitorTests.cs
+++ b/tests/Query/Builders/Visitors/GroupByExpressionVisitorTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq.Expressions;
+using Kafka.Ksql.Linq.Query.Builders;
+using Kafka.Ksql.Linq.Tests;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Builders.Visitors;
+
+public class GroupByExpressionVisitorTests
+{
+    [Fact]
+    public void Visit_CompositeKey_ReturnsCommaSeparatedKeys()
+    {
+        Expression<Func<TestEntity, object>> expr = e => new { e.Id, e.Type };
+        var visitor = new GroupByExpressionVisitor();
+        visitor.Visit(expr.Body);
+        var result = visitor.GetResult();
+        Assert.Equal("Id, Type", result);
+    }
+
+    private class Parent
+    {
+        public Child Child { get; set; } = new();
+    }
+
+    private class Child
+    {
+        public int Value { get; set; }
+    }
+
+    [Fact]
+    public void Visit_NestedProperty_ReturnsLeafPropertyName()
+    {
+        Expression<Func<Parent, object>> expr = p => p.Child.Value;
+        var visitor = new GroupByExpressionVisitor();
+        visitor.Visit(expr.Body);
+        var result = visitor.GetResult();
+        Assert.Equal("Value", result);
+    }
+}

--- a/tests/Query/Builders/Visitors/OrderByComplexityVisitorTests.cs
+++ b/tests/Query/Builders/Visitors/OrderByComplexityVisitorTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Linq.Expressions;
+using Kafka.Ksql.Linq.Query.Builders;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Builders.Visitors;
+
+public class OrderByComplexityVisitorTests
+{
+    private class Sample
+    {
+        public int Id { get; set; }
+        public int Score { get; set; }
+    }
+
+    [Fact]
+    public void Visit_ComplexExpression_SetsFlag()
+    {
+        Expression<Func<Sample, int>> expr = e => e.Id + e.Score * 2;
+        var visitor = new OrderByComplexityVisitor();
+        visitor.Visit(expr.Body);
+        Assert.True(visitor.HasComplexExpressions);
+    }
+
+    [Fact]
+    public void Visit_SimpleMemberExpression_FlagRemainsFalse()
+    {
+        Expression<Func<Sample, int>> expr = e => e.Id;
+        var visitor = new OrderByComplexityVisitor();
+        visitor.Visit(expr.Body);
+        Assert.False(visitor.HasComplexExpressions);
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for visitors
- test aggregate detection
- test group by extraction
- test order by complexity

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686203e15cdc83278b8b3c5a08c54a36