### PR TITLE
Add unit tests for join and retry components

### DIFF
--- a/tests/Query/Builders/Visitors/NonAggregateColumnVisitorTests.cs
+++ b/tests/Query/Builders/Visitors/NonAggregateColumnVisitorTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Kafka.Ksql.Linq.Query.Builders;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Builders.Visitors;
+
+public class NonAggregateColumnVisitorTests
+{
+    [Fact]
+    public void Visit_MemberOutsideAggregate_SetsFlag()
+    {
+        Expression<Func<TestEntity, int>> expr = e => e.Id;
+        var visitor = new NonAggregateColumnVisitor();
+        visitor.Visit(expr.Body);
+        Assert.True(visitor.HasNonAggregateColumns);
+    }
+
+    [Fact]
+    public void Visit_MemberInsideAggregate_DoesNotSetFlag()
+    {
+        Expression<Func<int>> expr = () => new[] { 1 }.Sum();
+        var visitor = new NonAggregateColumnVisitor();
+        visitor.Visit(expr.Body);
+        Assert.False(visitor.HasNonAggregateColumns);
+    }
+
+    [Fact]
+    public void Visit_MixedExpression_OnlyCountsNonAggregated()
+    {
+        Expression<Func<TestEntity, int>> expr = e => e.Id + new[] { e.Id }.Sum();
+        var visitor = new NonAggregateColumnVisitor();
+        visitor.Visit(expr.Body);
+        Assert.True(visitor.HasNonAggregateColumns);
+    }
+
+    private class TestEntity
+    {
+        public int Id { get; set; }
+    }
+}

--- a/tests/Query/JoinableEntitySetTests.cs
+++ b/tests/Query/JoinableEntitySetTests.cs
@@ -28,7 +28,7 @@ public class JoinableEntitySetTests
         public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>());
         public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
         public string GetTopicName() => typeof(T).Name;
-        public EntityModel GetEntityModel() => new EntityModel { EntityType = typeof(T), TopicAttribute = new TopicAttribute(typeof(T).Name), AllProperties = typeof(T).GetProperties(), KeyProperties = Array.Empty<System.Reflection.PropertyInfo>(), ValidationResult = new ValidationResult(true, new()) };
+        public EntityModel GetEntityModel() => new EntityModel { EntityType = typeof(T), TopicAttribute = new TopicAttribute(typeof(T).Name), AllProperties = typeof(T).GetProperties(), KeyProperties = Array.Empty<System.Reflection.PropertyInfo>(), ValidationResult = new ValidationResult { IsValid = true } };
         public IKsqlContext GetContext() => _context;
         public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) { await Task.CompletedTask; yield break; }
     }
@@ -54,7 +54,7 @@ public class JoinableEntitySetTests
         var third = new DummySet<GrandChildEntity>();
 
         var result = outer.Join(inner, o => o.Id, i => i.ParentId)
-                          .Join(third, o => o.Id, g => g.ChildId)
+                          .Join(third, (Expression<Func<TestEntity, int>>)(o => o.Id), g => g.ChildId)
                           .Select((o, i, g) => new { o.Id, g.Description });
 
         var list = await result.ToListAsync();

--- a/tests/Query/JoinableEntitySetTests.cs
+++ b/tests/Query/JoinableEntitySetTests.cs
@@ -1,0 +1,98 @@
+using Kafka.Ksql.Linq.Query.Linq;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query;
+
+public class JoinableEntitySetTests
+{
+    private class DummyContext : IKsqlContext
+    {
+        public IEntitySet<T> Set<T>() where T : class => throw new NotImplementedException();
+        public object GetEventSet(Type entityType) => throw new NotImplementedException();
+        public Dictionary<Type, EntityModel> GetEntityModels() => new();
+        public void Dispose() { }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private class DummySet<T> : IEntitySet<T> where T : class
+    {
+        private readonly IKsqlContext _context = new DummyContext();
+        public Task AddAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>());
+        public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public string GetTopicName() => typeof(T).Name;
+        public EntityModel GetEntityModel() => new EntityModel { EntityType = typeof(T), TopicAttribute = new TopicAttribute(typeof(T).Name), AllProperties = typeof(T).GetProperties(), KeyProperties = Array.Empty<System.Reflection.PropertyInfo>(), ValidationResult = new ValidationResult(true, new()) };
+        public IKsqlContext GetContext() => _context;
+        public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) { await Task.CompletedTask; yield break; }
+    }
+
+    [Fact]
+    public async Task Join_CreatesJoinResult_ForValidInputs()
+    {
+        var outer = new JoinableEntitySet<TestEntity>(new DummySet<TestEntity>());
+        var inner = new DummySet<ChildEntity>();
+
+        var result = outer.Join(inner, o => o.Id, i => i.ParentId)
+                          .Select((o, i) => new { o.Id, i.Name });
+
+        var list = await result.ToListAsync();
+        Assert.Empty(list);
+    }
+
+    [Fact]
+    public async Task Join_ThreeWayJoin_WorksCorrectly()
+    {
+        var outer = new JoinableEntitySet<TestEntity>(new DummySet<TestEntity>());
+        var inner = new DummySet<ChildEntity>();
+        var third = new DummySet<GrandChildEntity>();
+
+        var result = outer.Join(inner, o => o.Id, i => i.ParentId)
+                          .Join(third, o => o.Id, g => g.ChildId)
+                          .Select((o, i, g) => new { o.Id, g.Description });
+
+        var list = await result.ToListAsync();
+        Assert.Empty(list);
+    }
+
+    [Fact]
+    public void Join_NullArguments_Throws()
+    {
+        var outer = new JoinableEntitySet<TestEntity>(new DummySet<TestEntity>());
+        var inner = new DummySet<ChildEntity>();
+
+        Assert.Throws<ArgumentNullException>(() => outer.Join<ChildEntity, int>(null!, o => o.Id, i => i.ParentId));
+        Assert.Throws<ArgumentNullException>(() => outer.Join(inner, null!, i => i.ParentId));
+        Assert.Throws<ArgumentNullException>(() => outer.Join(inner, o => o.Id, null!));
+    }
+
+    [Fact]
+    public void ToString_ReturnsInformation()
+    {
+        var outer = new JoinableEntitySet<TestEntity>(new DummySet<TestEntity>());
+        var str = outer.ToString();
+        Assert.Contains("JoinableEntitySet", str);
+    }
+}
+
+public class TestEntity
+{
+    public int Id { get; set; }
+}
+
+public class ChildEntity
+{
+    public int ParentId { get; set; }
+    public string Name { get; set; } = string.Empty;
+}
+
+public class GrandChildEntity
+{
+    public int ChildId { get; set; }
+    public string Description { get; set; } = string.Empty;
+}

--- a/tests/Query/JoinableEntitySetTests.cs
+++ b/tests/Query/JoinableEntitySetTests.cs
@@ -39,7 +39,7 @@ public class JoinableEntitySetTests
         var outer = new JoinableEntitySet<TestEntity>(new DummySet<TestEntity>());
         var inner = new DummySet<ChildEntity>();
 
-        var result = outer.Join(inner, o => o.Id, i => i.ParentId)
+        var result = outer.Join<ChildEntity, object>(inner, o => (object)o.Id, i => (object)i.ParentId)
                           .Select((o, i) => new { o.Id, i.Name });
 
         var list = await result.ToListAsync();
@@ -53,8 +53,8 @@ public class JoinableEntitySetTests
         var inner = new DummySet<ChildEntity>();
         var third = new DummySet<GrandChildEntity>();
 
-        var result = outer.Join(inner, o => o.Id, i => i.ParentId)
-                          .Join(third, (Expression<Func<TestEntity, int>>)(o => o.Id), g => g.ChildId)
+        var result = outer.Join<ChildEntity, object>(inner, o => (object)o.Id, i => (object)i.ParentId)
+                          .Join<GrandChildEntity, object>(third, o => (object)o.Id, g => (object)g.ChildId)
                           .Select((o, i, g) => new { o.Id, g.Description });
 
         var list = await result.ToListAsync();

--- a/tests/Query/JoinableEntitySetTests.cs
+++ b/tests/Query/JoinableEntitySetTests.cs
@@ -54,7 +54,7 @@ public class JoinableEntitySetTests
         var third = new DummySet<GrandChildEntity>();
 
         var result = outer.Join<ChildEntity, object>(inner, o => (object)o.Id, i => (object)i.ParentId)
-                          .Join<GrandChildEntity, object>(third, o => (object)o.Id, g => (object)g.ChildId)
+                          .Join<GrandChildEntity, object>(third, (Expression<Func<TestEntity, object>>)(o => (object)o.Id), g => (object)g.ChildId)
                           .Select((o, i, g) => new { o.Id, g.Description });
 
         var list = await result.ToListAsync();

--- a/tests/Query/JoinableEntitySetTests.cs
+++ b/tests/Query/JoinableEntitySetTests.cs
@@ -1,5 +1,6 @@
 using Kafka.Ksql.Linq.Query.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Tests;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
@@ -78,21 +79,4 @@ public class JoinableEntitySetTests
         var str = outer.ToString();
         Assert.Contains("JoinableEntitySet", str);
     }
-}
-
-public class TestEntity
-{
-    public int Id { get; set; }
-}
-
-public class ChildEntity
-{
-    public int ParentId { get; set; }
-    public string Name { get; set; } = string.Empty;
-}
-
-public class GrandChildEntity
-{
-    public int ChildId { get; set; }
-    public string Description { get; set; } = string.Empty;
 }

--- a/tests/Query/Pipeline/ExpressionAnalysisResultTests.cs
+++ b/tests/Query/Pipeline/ExpressionAnalysisResultTests.cs
@@ -1,0 +1,43 @@
+using Kafka.Ksql.Linq.Query.Pipeline;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Pipeline;
+
+public class ExpressionAnalysisResultTests
+{
+    [Fact]
+    public void AnalyzeLinqExpression_DetectsFlags()
+    {
+        IQueryable<TestEntity> data = new List<TestEntity>().AsQueryable();
+        var query = data.Window(5).GroupBy(e => e.Id).Select(g => g.Sum(e => e.Id));
+
+        var generator = new DMLQueryGenerator();
+        var result = PrivateAccessor.InvokePrivate<ExpressionAnalysisResult>(generator, "AnalyzeLinqExpression", new[] { typeof(Expression) }, args: new object[] { query.Expression });
+
+        Assert.True(result.HasGroupBy);
+        Assert.True(result.HasAggregation);
+        Assert.True(result.HasWindow);
+    }
+
+    [Fact]
+    public void AnalyzeLinqExpression_NoAggregation()
+    {
+        IQueryable<TestEntity> data = new List<TestEntity>().AsQueryable();
+        var query = data.Where(e => e.Id > 0);
+        var generator = new DMLQueryGenerator();
+        var result = PrivateAccessor.InvokePrivate<ExpressionAnalysisResult>(generator, "AnalyzeLinqExpression", new[] { typeof(Expression) }, args: new object[] { query.Expression });
+
+        Assert.False(result.HasGroupBy);
+        Assert.False(result.HasAggregation);
+        Assert.False(result.HasWindow);
+    }
+
+    private class TestEntity
+    {
+        public int Id { get; set; }
+    }
+}

--- a/tests/Query/QueryMetadataTests.cs
+++ b/tests/Query/QueryMetadataTests.cs
@@ -1,0 +1,27 @@
+using Kafka.Ksql.Linq.Query.Pipeline;
+using Kafka.Ksql.Linq.Query;
+using System;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query;
+
+public class QueryMetadataTests
+{
+    [Fact]
+    public void WithProperty_AddsProperty()
+    {
+        var meta = new QueryMetadata(DateTime.UtcNow, "DML");
+        var updated = meta.WithProperty("key", 1);
+        Assert.Equal(1, updated.Properties!["key"]);
+        Assert.Null(meta.Properties);
+    }
+
+    [Fact]
+    public void GetProperty_ReturnsTypedValue()
+    {
+        var meta = new QueryMetadata(DateTime.UtcNow, "DML", null, new System.Collections.Generic.Dictionary<string, object>{{"val", 5}});
+        int? val = meta.GetProperty<int>("val");
+        Assert.Equal(5, val);
+        Assert.Null(meta.GetProperty<string>("missing"));
+    }
+}

--- a/tests/Query/TypedJoinResultEntitySetTests.cs
+++ b/tests/Query/TypedJoinResultEntitySetTests.cs
@@ -1,0 +1,67 @@
+using Kafka.Ksql.Linq.Query.Linq;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query;
+
+public class TypedJoinResultEntitySetTests
+{
+    private class DummyContext : IKsqlContext
+    {
+        public IEntitySet<T> Set<T>() where T : class => throw new NotImplementedException();
+        public object GetEventSet(Type entityType) => throw new NotImplementedException();
+        public Dictionary<Type, EntityModel> GetEntityModels() => new();
+        public void Dispose() { }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private class DummySet<T> : IEntitySet<T> where T : class
+    {
+        private readonly IKsqlContext _context = new DummyContext();
+        public Task AddAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>());
+        public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public string GetTopicName() => typeof(T).Name;
+        public EntityModel GetEntityModel() => new EntityModel { EntityType = typeof(T), TopicAttribute = new TopicAttribute(typeof(T).Name), AllProperties = typeof(T).GetProperties(), KeyProperties = Array.Empty<System.Reflection.PropertyInfo>(), ValidationResult = new ValidationResult(true, new()) };
+        public IKsqlContext GetContext() => _context;
+        public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) { await Task.CompletedTask; yield break; }
+    }
+
+    private record Result(int Id, string Name);
+
+    [Fact]
+    public async Task ToListAsync_ReturnsEmptyList()
+    {
+        var ctx = new DummyContext();
+        var outer = new DummySet<TestEntity>();
+        var inner = new DummySet<ChildEntity>();
+        var model = new EntityModel { EntityType = typeof(Result), TopicAttribute = new TopicAttribute("R"), AllProperties = typeof(Result).GetProperties(), KeyProperties = Array.Empty<System.Reflection.PropertyInfo>(), ValidationResult = new ValidationResult(true, new()) };
+
+        Expression<Func<TestEntity, ChildEntity, Result>> selector = (o, i) => new Result(o.Id, i.Name);
+        var set = new TypedJoinResultEntitySet<TestEntity, ChildEntity, Result>(ctx, model, outer, inner, o => o.Id, i => i.ParentId, selector);
+        var list = await set.ToListAsync();
+        Assert.Empty(list);
+        Assert.Equal("R", set.GetTopicName());
+    }
+
+    [Fact]
+    public void UnsupportedOperations_Throw()
+    {
+        var ctx = new DummyContext();
+        var outer = new DummySet<TestEntity>();
+        var inner = new DummySet<ChildEntity>();
+        var model = new EntityModel { EntityType = typeof(Result), TopicAttribute = new TopicAttribute("R"), AllProperties = typeof(Result).GetProperties(), KeyProperties = Array.Empty<System.Reflection.PropertyInfo>(), ValidationResult = new ValidationResult(true, new()) };
+        Expression<Func<TestEntity, ChildEntity, Result>> selector = (o, i) => new Result(o.Id, i.Name);
+        var set = new TypedJoinResultEntitySet<TestEntity, ChildEntity, Result>(ctx, model, outer, inner, o => o.Id, i => i.ParentId, selector);
+        Assert.Throws<NotSupportedException>(() => set.AddAsync(new Result(1, "a")));
+        Assert.Throws<NotSupportedException>(() => set.ForEachAsync(_ => Task.CompletedTask));
+    }
+}
+
+public class TestEntity { public int Id { get; set; } }
+public class ChildEntity { public int ParentId { get; set; } public string Name { get; set; } = string.Empty; }

--- a/tests/Query/TypedJoinResultEntitySetTests.cs
+++ b/tests/Query/TypedJoinResultEntitySetTests.cs
@@ -1,5 +1,6 @@
 using Kafka.Ksql.Linq.Query.Linq;
 using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Tests;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
@@ -62,6 +63,3 @@ public class TypedJoinResultEntitySetTests
         Assert.Throws<NotSupportedException>(() => set.ForEachAsync(_ => Task.CompletedTask));
     }
 }
-
-public class TestEntity { public int Id { get; set; } }
-public class ChildEntity { public int ParentId { get; set; } public string Name { get; set; } = string.Empty; }

--- a/tests/Query/ValidationResultTests.cs
+++ b/tests/Query/ValidationResultTests.cs
@@ -1,0 +1,26 @@
+using Kafka.Ksql.Linq.Query;
+using System.Linq;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query;
+
+public class ValidationResultTests
+{
+    [Fact]
+    public void Failure_CreatesInvalidResult()
+    {
+        var result = ValidationResult.Failure("a", "b");
+        Assert.False(result.IsValid);
+        Assert.Equal(2, result.Errors.Count);
+        Assert.Equal("a; b", result.GetErrorMessage());
+    }
+
+    [Fact]
+    public void Success_HasNoErrors()
+    {
+        var result = ValidationResult.Success;
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+        Assert.Equal(string.Empty, result.GetErrorMessage());
+    }
+}

--- a/tests/Query/ValidationResultTests.cs
+++ b/tests/Query/ValidationResultTests.cs
@@ -1,4 +1,4 @@
-using Kafka.Ksql.Linq.Query;
+using Kafka.Ksql.Linq.Query.Pipeline;
 using System.Linq;
 using Xunit;
 

--- a/tests/RetryReadyChainTests.cs
+++ b/tests/RetryReadyChainTests.cs
@@ -29,7 +29,7 @@ public class RetryReadyChainTests
         internal override EventSet<TestEntity> WithErrorPolicy(ErrorHandlingPolicy policy) { LastPolicy = policy; return this; }
     }
 
-    private static EntityModel CreateModel() => new() { EntityType = typeof(TestEntity), TopicAttribute = new TopicAttribute("t"), AllProperties = typeof(TestEntity).GetProperties(), KeyProperties = Array.Empty<PropertyInfo>(), ValidationResult = ValidationResult.Success };
+    private static EntityModel CreateModel() => new() { EntityType = typeof(TestEntity), TopicAttribute = new TopicAttribute("t"), AllProperties = typeof(TestEntity).GetProperties(), KeyProperties = Array.Empty<PropertyInfo>(), ValidationResult = new ValidationResult { IsValid = true } };
 
     [Fact]
     public void WithRetry_SetsPolicyAndReturnsSet()

--- a/tests/RetryReadyChainTests.cs
+++ b/tests/RetryReadyChainTests.cs
@@ -1,0 +1,65 @@
+using Kafka.Ksql.Linq;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests;
+
+public class RetryReadyChainTests
+{
+    private class DummyContext : IKsqlContext
+    {
+        public IEntitySet<T> Set<T>() where T : class => throw new NotImplementedException();
+        public object GetEventSet(Type entityType) => throw new NotImplementedException();
+        public Dictionary<Type, EntityModel> GetEntityModels() => new();
+        public void Dispose() { }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private class TestSet : EventSet<TestEntity>
+    {
+        public ErrorHandlingPolicy? LastPolicy { get; private set; }
+        public TestSet() : base(new DummyContext(), CreateModel()) { }
+        protected override Task SendEntityAsync(TestEntity entity, CancellationToken cancellationToken) => Task.CompletedTask;
+        public override async IAsyncEnumerator<TestEntity> GetAsyncEnumerator(CancellationToken cancellationToken = default) { await Task.CompletedTask; yield break; }
+        internal override EventSet<TestEntity> WithErrorPolicy(ErrorHandlingPolicy policy) { LastPolicy = policy; return this; }
+    }
+
+    private static EntityModel CreateModel() => new() { EntityType = typeof(TestEntity), TopicAttribute = new TopicAttribute("t"), AllProperties = typeof(TestEntity).GetProperties(), KeyProperties = Array.Empty<PropertyInfo>(), ValidationResult = ValidationResult.Success };
+
+    [Fact]
+    public void WithRetry_SetsPolicyAndReturnsSet()
+    {
+        var set = new TestSet();
+        var chain = new RetryReadyChain<TestEntity>(set);
+        var result = chain.WithRetry(2, TimeSpan.FromSeconds(2));
+
+        Assert.Same(set, result);
+        Assert.NotNull(set.LastPolicy);
+        Assert.Equal(ErrorAction.Retry, set.LastPolicy!.Action);
+        Assert.Equal(2, set.LastPolicy.RetryCount);
+        Assert.Equal(TimeSpan.FromSeconds(2), set.LastPolicy.RetryInterval);
+    }
+
+    [Fact]
+    public void WithRetry_NegativeCount_Throws()
+    {
+        var set = new TestSet();
+        var chain = new RetryReadyChain<TestEntity>(set);
+        Assert.Throws<ArgumentException>(() => chain.WithRetry(-1));
+    }
+
+    [Fact]
+    public void Build_ReturnsOriginalSet()
+    {
+        var set = new TestSet();
+        var chain = new RetryReadyChain<TestEntity>(set);
+        Assert.Same(set, chain.Build());
+    }
+
+    private class TestEntity { public int Id { get; set; } }
+}


### PR DESCRIPTION
## Summary
- cover joinable entity set join path and exceptions
- add visitor tests for non-aggregate columns
- test expression analysis result flags
- validate typed join result entity set behavior
- add retry ready chain tests
- add query metadata and validation result tests

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68620d590cbc8327a458fb0d6c8b7c25