### PR TITLE
Add unit tests for window components

### DIFF
--- a/tests/Core/Window/GroupByExpressionVisitorTests.cs
+++ b/tests/Core/Window/GroupByExpressionVisitorTests.cs
@@ -1,0 +1,40 @@
+using Kafka.Ksql.Linq.Core.Window;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Core.Window;
+
+public class GroupByExpressionVisitorTests
+{
+    private class Sample
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+    }
+
+    [Fact]
+    public void Visit_SingleProperty_AddsUppercaseName()
+    {
+        Expression<Func<Sample, object>> expr = x => x.Id;
+        var visitor = new GroupByExpressionVisitor();
+
+        visitor.Visit(expr.Body);
+
+        Assert.Contains("ID", visitor.GetColumns());
+    }
+
+    [Fact]
+    public void Visit_AnonymousType_AddsAllMembers()
+    {
+        Expression<Func<Sample, object>> expr = x => new { x.Id, x.Name };
+        var visitor = new GroupByExpressionVisitor();
+
+        visitor.Visit(expr.Body);
+
+        var cols = visitor.GetColumns();
+        Assert.Contains("ID", cols);
+        Assert.Contains("NAME", cols);
+    }
+}

--- a/tests/Core/Window/WindowAggregatedEntitySetTests.cs
+++ b/tests/Core/Window/WindowAggregatedEntitySetTests.cs
@@ -2,6 +2,7 @@ using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Core.Window;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;

--- a/tests/Core/Window/WindowAggregatedEntitySetTests.cs
+++ b/tests/Core/Window/WindowAggregatedEntitySetTests.cs
@@ -1,0 +1,91 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Window;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Core.Window;
+
+public class WindowAggregatedEntitySetTests
+{
+    private class DummyContext : IKsqlContext
+    {
+        public IEntitySet<T> Set<T>() where T : class => throw new NotImplementedException();
+        public object GetEventSet(Type entityType) => throw new NotImplementedException();
+        public Dictionary<Type, EntityModel> GetEntityModels() => new();
+        public void Dispose() { }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private class StubSet<T> : IEntitySet<T> where T : class
+    {
+        private readonly IKsqlContext _context;
+        private readonly EntityModel _model;
+        public StubSet(IKsqlContext context, EntityModel model)
+        {
+            _context = context;
+            _model = model;
+        }
+        public Task AddAsync(T entity, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>());
+        public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public string GetTopicName() => _model.TopicAttribute?.TopicName ?? typeof(T).Name;
+        public EntityModel GetEntityModel() => _model;
+        public IKsqlContext GetContext() => _context;
+        public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) { await Task.CompletedTask; yield break; }
+    }
+
+    private class SourceEntity
+    {
+        public int Id { get; set; }
+        [AvroTimestamp]
+        public DateTime Timestamp { get; set; }
+    }
+
+    private class ResultEntity
+    {
+        public int Count { get; set; }
+    }
+
+    private static WindowAggregatedEntitySet<SourceEntity, int, ResultEntity> CreateSet()
+    {
+        var context = new DummyContext();
+        var model = new EntityModel
+        {
+            EntityType = typeof(SourceEntity),
+            TopicAttribute = new TopicAttribute("orders"),
+            AllProperties = typeof(SourceEntity).GetProperties(),
+            KeyProperties = new[] { typeof(SourceEntity).GetProperty(nameof(SourceEntity.Id))! }
+        };
+        var baseSet = new StubSet<SourceEntity>(context, model);
+        Expression<Func<SourceEntity, int>> group = x => x.Id;
+        Expression<Func<IGrouping<int, SourceEntity>, ResultEntity>> agg = g => new ResultEntity { Count = g.Count() };
+        var config = new WindowAggregationConfig { WindowSize = TimeSpan.FromMinutes(5) };
+        return new WindowAggregatedEntitySet<SourceEntity, int, ResultEntity>(baseSet, 5, group, agg, config);
+    }
+
+    [Fact]
+    public void GetTopicName_BeginsWithBaseTopic()
+    {
+        var set = CreateSet();
+        Assert.StartsWith("orders_WINDOW_5MIN_AGG_", set.GetTopicName());
+    }
+
+    [Fact]
+    public async Task AddAsync_ThrowsNotSupported()
+    {
+        var set = CreateSet();
+        await Assert.ThrowsAsync<NotSupportedException>(() => set.AddAsync(new ResultEntity()));
+    }
+
+    [Fact]
+    public void ToString_IncludesTypeAndWindow()
+    {
+        var set = CreateSet();
+        var text = set.ToString();
+        Assert.Contains("ResultEntity", text);
+        Assert.Contains("5min", text);
+    }
+}

--- a/tests/Core/Window/WindowAggregatedEntitySetTests.cs
+++ b/tests/Core/Window/WindowAggregatedEntitySetTests.cs
@@ -3,6 +3,7 @@ using Kafka.Ksql.Linq.Core.Window;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/tests/Core/Window/WindowCollectionTests.cs
+++ b/tests/Core/Window/WindowCollectionTests.cs
@@ -1,0 +1,89 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Window;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Core.Window;
+
+public class WindowCollectionTests
+{
+    private class DummyContext : IKsqlContext
+    {
+        public IEntitySet<T> Set<T>() where T : class => throw new NotImplementedException();
+        public object GetEventSet(Type entityType) => throw new NotImplementedException();
+        public Dictionary<Type, EntityModel> GetEntityModels() => new();
+        public void Dispose() { }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private class StubSet<T> : IEntitySet<T> where T : class
+    {
+        private readonly IKsqlContext _context;
+        private readonly EntityModel _model;
+        public readonly List<T> Items = new();
+        public StubSet(IKsqlContext context, EntityModel model)
+        {
+            _context = context;
+            _model = model;
+        }
+        public Task AddAsync(T entity, CancellationToken cancellationToken = default) { Items.Add(entity); return Task.CompletedTask; }
+        public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>(Items));
+        public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(Items.Select(action));
+        public string GetTopicName() => _model.TopicAttribute?.TopicName ?? typeof(T).Name;
+        public EntityModel GetEntityModel() => _model;
+        public IKsqlContext GetContext() => _context;
+        public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) { foreach (var i in Items) { yield return i; await Task.Yield(); } }
+    }
+
+    private class Sample
+    {
+        public int Id { get; set; }
+        [AvroTimestamp]
+        public DateTime Timestamp { get; set; }
+    }
+
+    private static WindowCollection<Sample> CreateCollection(out StubSet<Sample> baseSet)
+    {
+        var context = new DummyContext();
+        var model = new EntityModel
+        {
+            EntityType = typeof(Sample),
+            TopicAttribute = new TopicAttribute("orders"),
+            AllProperties = typeof(Sample).GetProperties(),
+            KeyProperties = new[] { typeof(Sample).GetProperty(nameof(Sample.Id))! }
+        };
+        baseSet = new StubSet<Sample>(context, model);
+        return new WindowCollection<Sample>(baseSet, new[] { 5, 10 });
+    }
+
+    [Fact]
+    public void Indexer_NonConfiguredSize_Throws()
+    {
+        var collection = CreateCollection(out _);
+        Assert.Throws<ArgumentException>(() => collection[20]);
+    }
+
+    [Fact]
+    public void Indexer_SameSize_ReturnsSameInstance()
+    {
+        var collection = CreateCollection(out _);
+        var w1 = collection[5];
+        var w2 = collection[5];
+        Assert.Same(w1, w2);
+    }
+
+    [Fact]
+    public async Task GetAllWindowsAsync_ReturnsDataForAllSizes()
+    {
+        var collection = CreateCollection(out var baseSet);
+        baseSet.Items.Add(new Sample { Id = 1, Timestamp = DateTime.UtcNow });
+
+        var result = await collection.GetAllWindowsAsync();
+
+        Assert.Equal(new[] {5,10}, result.Keys.OrderBy(x=>x).ToArray());
+    }
+}

--- a/tests/Core/Window/WindowedEntitySetTests.cs
+++ b/tests/Core/Window/WindowedEntitySetTests.cs
@@ -1,0 +1,84 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Core.Window;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Core.Window;
+
+public class WindowedEntitySetTests
+{
+    private class DummyContext : IKsqlContext
+    {
+        public IEntitySet<T> Set<T>() where T : class => throw new NotImplementedException();
+        public object GetEventSet(Type entityType) => throw new NotImplementedException();
+        public Dictionary<Type, EntityModel> GetEntityModels() => new();
+        public void Dispose() { }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private class StubSet<T> : IEntitySet<T> where T : class
+    {
+        private readonly IKsqlContext _context;
+        private readonly EntityModel _model;
+        public readonly List<T> Items = new();
+        public StubSet(IKsqlContext context, EntityModel model)
+        {
+            _context = context;
+            _model = model;
+        }
+        public Task AddAsync(T entity, CancellationToken cancellationToken = default) { Items.Add(entity); return Task.CompletedTask; }
+        public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>(Items));
+        public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(Items.Select(action));
+        public string GetTopicName() => _model.TopicAttribute?.TopicName ?? typeof(T).Name;
+        public EntityModel GetEntityModel() => _model;
+        public IKsqlContext GetContext() => _context;
+        public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) { foreach (var i in Items) { yield return i; await Task.Yield(); } }
+    }
+
+    private class Sample
+    {
+        public int Id { get; set; }
+        [AvroTimestamp]
+        public DateTime Timestamp { get; set; }
+    }
+
+    private static WindowedEntitySet<Sample> CreateSet(out StubSet<Sample> baseSet)
+    {
+        var context = new DummyContext();
+        var model = new EntityModel
+        {
+            EntityType = typeof(Sample),
+            TopicAttribute = new TopicAttribute("orders"),
+            AllProperties = typeof(Sample).GetProperties(),
+            KeyProperties = new[] { typeof(Sample).GetProperty(nameof(Sample.Id))! }
+        };
+        baseSet = new StubSet<Sample>(context, model);
+        return new WindowedEntitySet<Sample>(baseSet, 5);
+    }
+
+    [Fact]
+    public void Constructor_RequiresTimestampProperty()
+    {
+        Assert.Throws<InvalidOperationException>(() => new WindowedEntitySet<WindowedEntitySetTests>(null!, 5));
+    }
+
+    [Fact]
+    public void GetWindowTableName_UsesBaseTopic()
+    {
+        var set = CreateSet(out _);
+        Assert.Equal("orders_WINDOW_5MIN", set.GetWindowTableName());
+    }
+
+    [Fact]
+    public async Task AddAsync_DelegatesToBase()
+    {
+        var set = CreateSet(out var baseSet);
+        var sample = new Sample { Id = 1, Timestamp = DateTime.UtcNow };
+        await set.AddAsync(sample);
+        Assert.Contains(sample, baseSet.Items);
+    }
+}

--- a/tests/Core/Window/WindowedEntitySetTests.cs
+++ b/tests/Core/Window/WindowedEntitySetTests.cs
@@ -60,10 +60,25 @@ public class WindowedEntitySetTests
         return new WindowedEntitySet<Sample>(baseSet, 5);
     }
 
+    private class NoTimestamp
+    {
+        public int Id { get; set; }
+    }
+
     [Fact]
     public void Constructor_RequiresTimestampProperty()
     {
-        Assert.Throws<InvalidOperationException>(() => new WindowedEntitySet<WindowedEntitySetTests>(null!, 5));
+        var context = new DummyContext();
+        var model = new EntityModel
+        {
+            EntityType = typeof(NoTimestamp),
+            TopicAttribute = new TopicAttribute("orders"),
+            AllProperties = typeof(NoTimestamp).GetProperties(),
+            KeyProperties = new[] { typeof(NoTimestamp).GetProperty(nameof(NoTimestamp.Id))! }
+        };
+        var baseSet = new StubSet<NoTimestamp>(context, model);
+
+        Assert.Throws<InvalidOperationException>(() => new WindowedEntitySet<NoTimestamp>(baseSet, 5));
     }
 
     [Fact]

--- a/tests/Messaging/Producers/Core/KafkaProducerTests.cs
+++ b/tests/Messaging/Producers/Core/KafkaProducerTests.cs
@@ -18,6 +18,7 @@ public class KafkaProducerTests
         public string Name => "dummy";
         public Handle Handle => throw new NotImplementedException();
         public int AddBrokers(string brokers) => 0;
+        public void SetSaslCredentials(string username, string password) { }
         public void Dispose() { }
         public void Flush(CancellationToken cancellationToken = default) { }
         public int Flush(TimeSpan timeout) => 0;
@@ -27,7 +28,7 @@ public class KafkaProducerTests
             Produced.Add((topicPartition, message));
             handler?.Invoke(new DeliveryReport<object, object> { TopicPartition = topicPartition });
         }
-        public void Poll(TimeSpan timeout) { }
+        public int Poll(TimeSpan timeout) => 0;
         public Task<DeliveryResult<object, object>> ProduceAsync(string topic, Message<object, object> message, CancellationToken cancellationToken = default)
             => throw new NotImplementedException();
         public Task<DeliveryResult<object, object>> ProduceAsync(TopicPartition topicPartition, Message<object, object> message, CancellationToken cancellationToken = default)
@@ -41,6 +42,13 @@ public class KafkaProducerTests
                 Message = message
             });
         }
+        public void InitTransactions(TimeSpan timeout) { }
+        public void BeginTransaction() { }
+        public void CommitTransaction(TimeSpan timeout) { }
+        public void CommitTransaction() { }
+        public void AbortTransaction(TimeSpan timeout) { }
+        public void AbortTransaction() { }
+        public void SendOffsetsToTransaction(IEnumerable<TopicPartitionOffset> offsets, IConsumerGroupMetadata groupMetadata, TimeSpan timeout) { }
     }
 
     private class Sample

--- a/tests/Messaging/Producers/Core/KafkaProducerTests.cs
+++ b/tests/Messaging/Producers/Core/KafkaProducerTests.cs
@@ -1,0 +1,75 @@
+using Confluent.Kafka;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Messaging.Producers.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Messaging.Producers.Core;
+
+public class KafkaProducerTests
+{
+    private class DummyProducer : IProducer<object, object>
+    {
+        public List<(TopicPartition Partition, Message<object, object> Message)> Produced { get; } = new();
+        public string Name => "dummy";
+        public Handle Handle => throw new NotImplementedException();
+        public int AddBrokers(string brokers) => 0;
+        public void Dispose() { }
+        public void Flush(CancellationToken cancellationToken = default) { }
+        public int Flush(TimeSpan timeout) => 0;
+        public void Produce(string topic, Message<object, object> message, Action<DeliveryReport<object, object>>? handler = null) => throw new NotImplementedException();
+        public void Produce(TopicPartition topicPartition, Message<object, object> message, Action<DeliveryReport<object, object>>? handler = null)
+        {
+            Produced.Add((topicPartition, message));
+            handler?.Invoke(new DeliveryReport<object, object> { TopicPartition = topicPartition });
+        }
+        public void Poll(TimeSpan timeout) { }
+        public Task<DeliveryResult<object, object>> ProduceAsync(string topic, Message<object, object> message, CancellationToken cancellationToken = default)
+            => throw new NotImplementedException();
+        public Task<DeliveryResult<object, object>> ProduceAsync(TopicPartition topicPartition, Message<object, object> message, CancellationToken cancellationToken = default)
+        {
+            Produced.Add((topicPartition, message));
+            return Task.FromResult(new DeliveryResult<object, object>
+            {
+                TopicPartition = topicPartition,
+                Offset = new Offset(1),
+                Status = PersistenceStatus.Persisted,
+                Message = message
+            });
+        }
+    }
+
+    private class Sample
+    {
+        public int Id { get; set; }
+    }
+
+    private static EntityModel CreateModel()
+    {
+        return new EntityModel
+        {
+            EntityType = typeof(Sample),
+            TopicAttribute = new TopicAttribute("orders"),
+            AllProperties = typeof(Sample).GetProperties(),
+            KeyProperties = new[] { typeof(Sample).GetProperty(nameof(Sample.Id))! }
+        };
+    }
+
+    [Fact]
+    public async Task SendAsync_ProducesMessage()
+    {
+        var producer = new DummyProducer();
+        var kp = new KafkaProducer<Sample>(producer, new Confluent.Kafka.NullSerializer<object>(), new Confluent.Kafka.NullSerializer<object>(), "orders", CreateModel(), NullLoggerFactory.Instance);
+
+        var entity = new Sample { Id = 1 };
+        var result = await kp.SendAsync(entity);
+
+        Assert.Single(producer.Produced);
+        Assert.Equal("orders", producer.Produced[0].Partition.Topic);
+        Assert.Equal(1, result.Offset);
+    }
+}

--- a/tests/StateStore/Extensions/WindowedEntitySetTests.cs
+++ b/tests/StateStore/Extensions/WindowedEntitySetTests.cs
@@ -1,0 +1,82 @@
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.StateStore.Core;
+using Kafka.Ksql.Linq.StateStore.Extensions;
+using Kafka.Ksql.Linq.StateStore.Management;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.StateStore.Extensions;
+
+public class WindowedEntitySetTests
+{
+    private class DummyContext : IKsqlContext
+    {
+        public IEntitySet<T> Set<T>() where T : class => throw new NotImplementedException();
+        public object GetEventSet(Type entityType) => throw new NotImplementedException();
+        public Dictionary<Type, EntityModel> GetEntityModels() => new();
+        public void Dispose() { }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private class StubSet<T> : IEntitySet<T> where T : class
+    {
+        private readonly IKsqlContext _context;
+        private readonly EntityModel _model;
+        public readonly List<T> Added = new();
+        public readonly List<T> Items = new();
+        public StubSet(IKsqlContext context, EntityModel model)
+        {
+            _context = context;
+            _model = model;
+        }
+        public Task AddAsync(T entity, CancellationToken cancellationToken = default) { Added.Add(entity); Items.Add(entity); return Task.CompletedTask; }
+        public Task<List<T>> ToListAsync(CancellationToken cancellationToken = default) => Task.FromResult(new List<T>(Items));
+        public Task ForEachAsync(Func<T, Task> action, TimeSpan timeout = default, CancellationToken cancellationToken = default) => Task.WhenAll(Items.Select(action));
+        public string GetTopicName() => _model.TopicAttribute?.TopicName ?? typeof(T).Name;
+        public EntityModel GetEntityModel() => _model;
+        public IKsqlContext GetContext() => _context;
+        public async IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default) { foreach (var i in Items) { yield return i; await Task.Yield(); } }
+    }
+
+    private class Sample
+    {
+        public int Id { get; set; }
+    }
+
+    private static WindowedEntitySet<Sample> CreateSet(out StubSet<Sample> baseSet)
+    {
+        var context = new DummyContext();
+        var model = new EntityModel
+        {
+            EntityType = typeof(Sample),
+            TopicAttribute = new TopicAttribute("orders"),
+            AllProperties = typeof(Sample).GetProperties(),
+            KeyProperties = new[] { typeof(Sample).GetProperty(nameof(Sample.Id))! }
+        };
+        baseSet = new StubSet<Sample>(context, model);
+        var manager = new StateStoreManager(Options.Create(new KsqlDslOptions()));
+        return new WindowedEntitySet<Sample>(baseSet, 5, manager, model);
+    }
+
+    [Fact]
+    public async Task AddAsync_PersistsEntity()
+    {
+        var set = CreateSet(out var baseSet);
+        var entity = new Sample { Id = 1 };
+        await set.AddAsync(entity);
+        Assert.Contains(entity, baseSet.Added);
+        Assert.Contains(entity, set.GetStateStore().All().Select(k=>k.Value));
+    }
+
+    [Fact]
+    public void GetWindowTableName_UsesBaseTopic()
+    {
+        var set = CreateSet(out _);
+        Assert.Equal("orders_WINDOW_5MIN", set.GetWindowTableName());
+    }
+}

--- a/tests/StateStore/Extensions/WindowedEntitySetTests.cs
+++ b/tests/StateStore/Extensions/WindowedEntitySetTests.cs
@@ -1,5 +1,6 @@
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.StateStore.Core;
+using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.StateStore.Extensions;
 using Kafka.Ksql.Linq.StateStore.Management;
 using Microsoft.Extensions.Options;

--- a/tests/StateStore/Monitoring/ReadyStateMonitorTests.cs
+++ b/tests/StateStore/Monitoring/ReadyStateMonitorTests.cs
@@ -3,6 +3,7 @@ using Kafka.Ksql.Linq.StateStore.Monitoring;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -12,23 +13,32 @@ public class ReadyStateMonitorTests
 {
     private class DummyConsumer : IConsumer<object, object>
     {
-        public List<TopicPartition> Assignment { get; set; } = new();
+        public List<TopicPartition> Assignment { get; } = new();
         public void Assign(TopicPartition partition) { }
         public void Assign(IEnumerable<TopicPartitionOffset> partitions) { }
         public void Assign(IEnumerable<TopicPartition> partitions) { }
+        public void IncrementalAssign(IEnumerable<TopicPartitionOffset> partitions) { }
+        public void IncrementalAssign(IEnumerable<TopicPartition> partitions) { }
+        public void IncrementalUnassign(IEnumerable<TopicPartition> partitions) { }
         public void Close() { }
         public void Dispose() { }
         public int AddBrokers(string brokers) => 0;
         public void Pause(IEnumerable<TopicPartition> partitions) { }
-        public void Poll(TimeSpan timeout) { }
+        public int Poll(TimeSpan timeout) => 0;
         public ConsumeResult<object, object>? Consume(CancellationToken cancellationToken = default) => null;
         public ConsumeResult<object, object>? Consume(TimeSpan timeout) => null;
+        public ConsumeResult<object, object>? Consume(int millisecondsTimeout) => null;
         public void Resume(IEnumerable<TopicPartition> partitions) { }
         public void Seek(TopicPartitionOffset tpo) { }
         public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout) => new WatermarkOffsets(0, 0);
         public Offset Position(TopicPartition partition) => new Offset(0);
-        public List<TopicPartition> Subscription => new();
+        public List<string> Subscription => new();
         public void StoreOffset(ConsumeResult<object, object> result) { }
+        public void StoreOffset(TopicPartitionOffset offset) { }
+        public List<TopicPartitionOffset> OffsetsForTimes(IEnumerable<TopicPartitionTimestamp> timestamps, TimeSpan timeout) => new();
+        public WatermarkOffsets GetWatermarkOffsets(TopicPartition partition) => new WatermarkOffsets(0, 0);
+        public List<TopicPartitionOffset> Committed(IEnumerable<TopicPartition> partitions, TimeSpan timeout) => new();
+        public List<TopicPartition> Commit(IEnumerable<TopicPartitionOffset> offsets) => new();
         public void Subscribe(string topic) { }
         public void Subscribe(IEnumerable<string> topics) { }
         public void Unassign() { }
@@ -36,12 +46,11 @@ public class ReadyStateMonitorTests
         public string MemberId => "";
         public Handle Handle => throw new NotImplementedException();
         public string Name => "dummy";
-        public string ConsumerGroupMetadata => "";
+        public IConsumerGroupMetadata ConsumerGroupMetadata => null!;
+        public void SetSaslCredentials(string username, string password) { }
         public event EventHandler<Error>? Error;
         public void OnError(Error error) => Error?.Invoke(this, error);
-        public List<TopicPartition> Assignment { get; } = new();
-        public List<TopicPartition> Commit(IEnumerable<TopicPartitionOffset> offsets) => new();
-        public List<TopicPartitionOffset> Committed(TimeSpan timeout) => new();
+        public void Commit() { }
         public void Commit(ConsumeResult<object, object> result) { }
         public void Commit(IEnumerable<TopicPartitionOffset> offsets) { }
     }

--- a/tests/StateStore/Monitoring/ReadyStateMonitorTests.cs
+++ b/tests/StateStore/Monitoring/ReadyStateMonitorTests.cs
@@ -1,0 +1,65 @@
+using Confluent.Kafka;
+using Kafka.Ksql.Linq.StateStore.Monitoring;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.StateStore.Monitoring;
+
+public class ReadyStateMonitorTests
+{
+    private class DummyConsumer : IConsumer<object, object>
+    {
+        public List<TopicPartition> Assignment { get; set; } = new();
+        public void Assign(TopicPartition partition) { }
+        public void Assign(IEnumerable<TopicPartitionOffset> partitions) { }
+        public void Assign(IEnumerable<TopicPartition> partitions) { }
+        public void Close() { }
+        public void Dispose() { }
+        public int AddBrokers(string brokers) => 0;
+        public void Pause(IEnumerable<TopicPartition> partitions) { }
+        public void Poll(TimeSpan timeout) { }
+        public ConsumeResult<object, object>? Consume(CancellationToken cancellationToken = default) => null;
+        public ConsumeResult<object, object>? Consume(TimeSpan timeout) => null;
+        public void Resume(IEnumerable<TopicPartition> partitions) { }
+        public void Seek(TopicPartitionOffset tpo) { }
+        public WatermarkOffsets QueryWatermarkOffsets(TopicPartition topicPartition, TimeSpan timeout) => new WatermarkOffsets(0, 0);
+        public Offset Position(TopicPartition partition) => new Offset(0);
+        public List<TopicPartition> Subscription => new();
+        public void StoreOffset(ConsumeResult<object, object> result) { }
+        public void Subscribe(string topic) { }
+        public void Subscribe(IEnumerable<string> topics) { }
+        public void Unassign() { }
+        public void Unsubscribe() { }
+        public string MemberId => "";
+        public Handle Handle => throw new NotImplementedException();
+        public string Name => "dummy";
+        public string ConsumerGroupMetadata => "";
+        public event EventHandler<Error>? Error;
+        public void OnError(Error error) => Error?.Invoke(this, error);
+        public List<TopicPartition> Assignment { get; } = new();
+        public List<TopicPartition> Commit(IEnumerable<TopicPartitionOffset> offsets) => new();
+        public List<TopicPartitionOffset> Committed(TimeSpan timeout) => new();
+        public void Commit(ConsumeResult<object, object> result) { }
+        public void Commit(IEnumerable<TopicPartitionOffset> offsets) { }
+    }
+
+    private class TestMonitor : ReadyStateMonitor
+    {
+        public TestMonitor() : base(new DummyConsumer(), "t", NullLoggerFactory.Instance) { }
+        public void TriggerReady() => typeof(ReadyStateMonitor).GetMethod("OnReadyStateChanged", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(this, new object[] { new ReadyStateChangedEventArgs { TopicName = "t", IsReady = true } });
+    }
+
+    [Fact]
+    public async Task WaitUntilReadyAsync_CompletesWhenTriggered()
+    {
+        var monitor = new TestMonitor();
+        var task = monitor.WaitUntilReadyAsync(TimeSpan.FromSeconds(1));
+        monitor.TriggerReady();
+        var result = await task;
+        Assert.True(result);
+    }
+}

--- a/tests/StateStore/Monitoring/ReadyStateMonitorTests.cs
+++ b/tests/StateStore/Monitoring/ReadyStateMonitorTests.cs
@@ -15,10 +15,12 @@ public class ReadyStateMonitorTests
     {
         public List<TopicPartition> Assignment { get; } = new();
         public void Assign(TopicPartition partition) { }
+        public void Assign(TopicPartitionOffset partition) { }
         public void Assign(IEnumerable<TopicPartitionOffset> partitions) { }
         public void Assign(IEnumerable<TopicPartition> partitions) { }
         public void IncrementalAssign(IEnumerable<TopicPartitionOffset> partitions) { }
         public void IncrementalAssign(IEnumerable<TopicPartition> partitions) { }
+        public void IncrementalUnassign(IEnumerable<TopicPartitionOffset> partitions) { }
         public void IncrementalUnassign(IEnumerable<TopicPartition> partitions) { }
         public void Close() { }
         public void Dispose() { }
@@ -38,7 +40,7 @@ public class ReadyStateMonitorTests
         public List<TopicPartitionOffset> OffsetsForTimes(IEnumerable<TopicPartitionTimestamp> timestamps, TimeSpan timeout) => new();
         public WatermarkOffsets GetWatermarkOffsets(TopicPartition partition) => new WatermarkOffsets(0, 0);
         public List<TopicPartitionOffset> Committed(IEnumerable<TopicPartition> partitions, TimeSpan timeout) => new();
-        public List<TopicPartition> Commit(IEnumerable<TopicPartitionOffset> offsets) => new();
+        public List<TopicPartitionOffset> Committed(TimeSpan timeout) => new();
         public void Subscribe(string topic) { }
         public void Subscribe(IEnumerable<string> topics) { }
         public void Unassign() { }
@@ -50,7 +52,7 @@ public class ReadyStateMonitorTests
         public void SetSaslCredentials(string username, string password) { }
         public event EventHandler<Error>? Error;
         public void OnError(Error error) => Error?.Invoke(this, error);
-        public void Commit() { }
+        public List<TopicPartitionOffset> Commit() => new();
         public void Commit(ConsumeResult<object, object> result) { }
         public void Commit(IEnumerable<TopicPartitionOffset> offsets) { }
     }

--- a/tests/Window/Finalization/WindowFinalConsumerTests.cs
+++ b/tests/Window/Finalization/WindowFinalConsumerTests.cs
@@ -1,4 +1,5 @@
 using Kafka.Ksql.Linq.StateStore.Core;
+using Kafka.Ksql.Linq.StateStore.Configuration;
 using Kafka.Ksql.Linq.Window.Finalization;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;

--- a/tests/Window/Finalization/WindowFinalConsumerTests.cs
+++ b/tests/Window/Finalization/WindowFinalConsumerTests.cs
@@ -1,0 +1,40 @@
+using Kafka.Ksql.Linq.StateStore.Core;
+using Kafka.Ksql.Linq.Window.Finalization;
+using Microsoft.Extensions.Logging.Abstractions;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Window.Finalization;
+
+public class WindowFinalConsumerTests
+{
+    [Fact]
+    public void GetFinalizedWindow_ReturnsStoredMessage()
+    {
+        var store = new RocksDbStateStore<string, WindowFinalMessage>("test", new StateStoreOptions { EnableCache = false }, NullLoggerFactory.Instance);
+        var consumer = new WindowFinalConsumer(store, NullLoggerFactory.Instance);
+        var msg = new WindowFinalMessage { WindowKey = "w", WindowMinutes = 5, WindowStart = DateTime.UtcNow, WindowEnd = DateTime.UtcNow.AddMinutes(5), PodId = "p" };
+        store.Put("w", msg);
+
+        var result = consumer.GetFinalizedWindow("w");
+
+        Assert.Equal(msg.WindowKey, result?.WindowKey);
+    }
+
+    [Fact]
+    public void GetFinalizedWindowsBySize_FiltersByWindowMinutes()
+    {
+        var store = new RocksDbStateStore<string, WindowFinalMessage>("t", new StateStoreOptions { EnableCache = false }, NullLoggerFactory.Instance);
+        var consumer = new WindowFinalConsumer(store, NullLoggerFactory.Instance);
+        var m1 = new WindowFinalMessage { WindowKey = "w1", WindowMinutes = 5, WindowStart = DateTime.UtcNow, WindowEnd = DateTime.UtcNow.AddMinutes(5), PodId = "p" };
+        var m2 = new WindowFinalMessage { WindowKey = "w2", WindowMinutes = 10, WindowStart = DateTime.UtcNow, WindowEnd = DateTime.UtcNow.AddMinutes(10), PodId = "p" };
+        store.Put("w1", m1);
+        store.Put("w2", m2);
+
+        var list = consumer.GetFinalizedWindowsBySize(5);
+
+        Assert.Single(list);
+        Assert.Equal("w1", list[0].WindowKey);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for GroupByExpressionVisitor
- cover WindowAggregatedEntitySet behaviour
- verify WindowCollection logic
- test WindowedEntitySet validation
- add KafkaProducer send test
- check Extension WindowedEntitySet
- test ReadyStateMonitor wait logic
- cover WindowFinalConsumer store access

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68621a9903ec83279b0a767e81dedccb