### PR TITLE
Add having clause test cases

### DIFF
--- a/tests/Query/Builders/HavingClauseBuilderTests.cs
+++ b/tests/Query/Builders/HavingClauseBuilderTests.cs
@@ -26,4 +26,59 @@ public class HavingClauseBuilderTests
         var sql = builder.Build(expr.Body);
         Assert.Equal("(SUM(Id) > 5)", sql);
     }
+
+    private class Order
+    {
+        public decimal Amount { get; set; }
+        public decimal Price { get; set; }
+        public int Quantity { get; set; }
+    }
+
+    [Fact]
+    public void Build_AndCondition_ReturnsCombinedExpression()
+    {
+        Expression<Func<IGrouping<int, Order>, bool>> expr =
+            g => g.Count() > 10 && g.Sum(x => x.Amount) < 5000;
+
+        var builder = new HavingClauseBuilder();
+        var sql = builder.Build(expr.Body);
+
+        Assert.Equal("((COUNT(*) > 10) AND (SUM(Amount) < 5000))", sql);
+    }
+
+    [Fact]
+    public void Build_OrCondition_ReturnsCombinedExpression()
+    {
+        Expression<Func<IGrouping<int, Order>, bool>> expr =
+            g => g.Average(x => x.Price) > 100 || g.Min(x => x.Quantity) < 2;
+
+        var builder = new HavingClauseBuilder();
+        var sql = builder.Build(expr.Body);
+
+        Assert.Equal("((AVG(Price) > 100) OR (MIN(Quantity) < 2))", sql);
+    }
+
+    [Fact]
+    public void Build_NestedCondition_MaintainsParentheses()
+    {
+        Expression<Func<IGrouping<int, Order>, bool>> expr =
+            g => (g.Count() > 5 && g.Max(x => x.Amount) < 1000) || g.Sum(x => x.Amount) > 3000;
+
+        var builder = new HavingClauseBuilder();
+        var sql = builder.Build(expr.Body);
+
+        Assert.Equal("(((COUNT(*) > 5) AND (MAX(Amount) < 1000)) OR (SUM(Amount) > 3000))", sql);
+    }
+
+    [Fact]
+    public void Build_NotCondition_ReturnsNegatedExpression()
+    {
+        Expression<Func<IGrouping<int, Order>, bool>> expr =
+            g => !(g.Count() < 3 || g.Sum(x => x.Amount) > 10000);
+
+        var builder = new HavingClauseBuilder();
+        var sql = builder.Build(expr.Body);
+
+        Assert.Equal("NOT (((COUNT(*) < 3) OR (SUM(Amount) > 10000)))", sql);
+    }
 }


### PR DESCRIPTION
## Summary
- expand HavingClauseBuilderTests with complex aggregate conditions

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686237c2af388327988e659259a1d429