### PR TITLE
Add test for GroupBy-Select-OrderBy

### DIFF
--- a/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
@@ -347,4 +347,27 @@ public class DMLQueryGeneratorTests
         Assert.Contains("SUM", result);
         Assert.Contains("EMIT CHANGES", result);
     }
+
+    [Fact]
+    public void GenerateLinqQuery_GroupBySelectOrderBy_ReturnsExpectedQuery()
+    {
+        var orders = new List<Order>().AsQueryable();
+
+        var query = orders
+            .GroupBy(o => o.CustomerId)
+            .Select(g => new
+            {
+                g.Key,
+                Total = g.Sum(o => o.Amount)
+            })
+            .OrderBy(x => x.Total);
+
+        var generator = new DMLQueryGenerator();
+        var result = generator.GenerateLinqQuery("orders", query.Expression, false);
+
+        Assert.Contains("GROUP BY", result);
+        Assert.Contains("SUM", result);
+        Assert.Contains("ORDER BY", result);
+        Assert.Contains("EMIT CHANGES", result);
+    }
 }


### PR DESCRIPTION
## Summary
- cover GroupBy with Select and OrderBy in DMLQueryGeneratorTests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686251de10d88327b2d2a402bc0a74fd