### PR TITLE
Add OrderByDescending test

### DIFF
--- a/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
@@ -370,4 +370,28 @@ public class DMLQueryGeneratorTests
         Assert.Contains("ORDER BY", result);
         Assert.Contains("EMIT CHANGES", result);
     }
+
+    [Fact]
+    public void GenerateLinqQuery_GroupBySelectOrderByDescending_ReturnsExpectedQuery()
+    {
+        var orders = new List<Order>().AsQueryable();
+
+        var query = orders
+            .GroupBy(o => o.CustomerId)
+            .Select(g => new
+            {
+                g.Key,
+                Total = g.Sum(o => o.Amount)
+            })
+            .OrderByDescending(x => x.Total); // descending sort
+
+        var generator = new DMLQueryGenerator();
+        var result = generator.GenerateLinqQuery("orders", query.Expression, false);
+
+        Assert.Contains("GROUP BY", result);
+        Assert.Contains("SUM", result);
+        Assert.Contains("ORDER BY", result);
+        Assert.Contains("DESC", result);
+        Assert.Contains("EMIT CHANGES", result);
+    }
 }


### PR DESCRIPTION
## Summary
- extend DMLQueryGeneratorTests with OrderByDescending coverage

## Testing
- `dotnet test Kafka.Ksql.Linq.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625389396483278456d634efab43cc