### PR TITLE
Add test for NOT IN translation

### DIFF
--- a/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
@@ -507,4 +507,29 @@ public class DMLQueryGeneratorTests
         Assert.Contains(")", result);
         Assert.Contains("EMIT CHANGES", result);
     }
+
+    [Fact]
+    public void GenerateLinqQuery_WhereNotInClause_ReturnsExpectedQuery()
+    {
+        var excludedRegions = new[] { "CN", "RU" };
+        var orders = new List<Order>().AsQueryable();
+
+        var query = orders
+            .Where(o => !excludedRegions.Contains(o.Region))
+            .Select(o => new
+            {
+                o.CustomerId,
+                o.Region,
+                o.Amount
+            });
+
+        var generator = new DMLQueryGenerator();
+        var result = generator.GenerateLinqQuery("orders", query.Expression, false);
+
+        Assert.Contains("WHERE", result);
+        Assert.Contains("NOT IN", result);
+        Assert.Contains("'CN'", result);
+        Assert.Contains("'RU'", result);
+        Assert.Contains("EMIT CHANGES", result);
+    }
 }


### PR DESCRIPTION
## Summary
- add test ensuring `!Contains` in LINQ becomes `NOT IN` in generated KSQL

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686262414c308327805161107c2cd7ce