### PR TITLE
Add group by expression key test

### DIFF
--- a/src/Query/groupby_clause_builder.cs
+++ b/src/Query/groupby_clause_builder.cs
@@ -178,7 +178,7 @@ internal class GroupByExpressionVisitor : ExpressionVisitor
             "DayOfWeek", "DayOfYear", "WeekOfYear",
             
             // 文字列関数（部分）
-            "Substring", "Left", "Right", "ToUpper", "ToLower",
+            "Substring", "Left", "Right", "ToUpper", "ToLower", "Upper", "Lower",
             
             // 数値関数（部分）
             "Floor", "Ceiling", "Round",
@@ -216,6 +216,8 @@ internal class GroupByExpressionVisitor : ExpressionVisitor
             "Right" => ProcessRightFunction(methodCall),
             "ToUpper" => ProcessSimpleFunction("UPPER", methodCall),
             "ToLower" => ProcessSimpleFunction("LOWER", methodCall),
+            "Upper" => ProcessSimpleFunction("UPPER", methodCall),
+            "Lower" => ProcessSimpleFunction("LOWER", methodCall),
 
             // 数値関数
             "Floor" => ProcessSimpleFunction("FLOOR", methodCall),

--- a/src/Query/groupby_clause_builder.cs
+++ b/src/Query/groupby_clause_builder.cs
@@ -178,7 +178,7 @@ internal class GroupByExpressionVisitor : ExpressionVisitor
             "DayOfWeek", "DayOfYear", "WeekOfYear",
             
             // 文字列関数（部分）
-            "Substring", "Left", "Right", "Upper", "Lower",
+            "Substring", "Left", "Right", "ToUpper", "ToLower",
             
             // 数値関数（部分）
             "Floor", "Ceiling", "Round",
@@ -214,8 +214,8 @@ internal class GroupByExpressionVisitor : ExpressionVisitor
             "Substring" => ProcessSubstringFunction(methodCall),
             "Left" => ProcessLeftFunction(methodCall),
             "Right" => ProcessRightFunction(methodCall),
-            "Upper" => ProcessSimpleFunction("UPPER", methodCall),
-            "Lower" => ProcessSimpleFunction("LOWER", methodCall),
+            "ToUpper" => ProcessSimpleFunction("UPPER", methodCall),
+            "ToLower" => ProcessSimpleFunction("LOWER", methodCall),
 
             // 数値関数
             "Floor" => ProcessSimpleFunction("FLOOR", methodCall),

--- a/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DMLQueryGeneratorTests.cs
@@ -583,4 +583,28 @@ public class DMLQueryGeneratorTests
         Assert.Contains("CustomerId", result);
         Assert.Contains("EMIT CHANGES", result);
     }
+
+    [Fact]
+    public void GenerateLinqQuery_GroupByWithExpressionKey_ReturnsExpectedQuery()
+    {
+        var orders = new List<Order>().AsQueryable();
+
+        var query = orders
+            .GroupBy(o => o.Region.ToUpper())
+            .Where(g => g.Sum(x => x.Amount) > 500)
+            .Select(g => new
+            {
+                RegionUpper = g.Key,
+                TotalAmount = g.Sum(x => x.Amount)
+            });
+
+        var generator = new DMLQueryGenerator();
+        var result = generator.GenerateLinqQuery("orders", query.Expression, false);
+
+        Assert.Contains("GROUP BY", result);
+        Assert.Contains("UPPER", result);
+        Assert.Contains("HAVING", result);
+        Assert.Contains("SUM", result);
+        Assert.Contains("EMIT CHANGES", result);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure LINQ GroupBy handles expression keys

## Testing
- `dotnet test --no-build tests/Kafka.Ksql.Linq.Tests.csproj -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862949ed8fc832784b764ba0a90d485