### PR TITLE
Add InferTypeFromMethodName tests

### DIFF
--- a/src/Query/ksql_function_registry.cs
+++ b/src/Query/ksql_function_registry.cs
@@ -207,6 +207,32 @@ internal static class KsqlFunctionRegistry
     }
 
     /// <summary>
+    /// メソッド名からKSQL型を推測
+    /// </summary>
+    public static string InferTypeFromMethodName(string methodName)
+    {
+        var name = methodName.ToUpperInvariant();
+
+        return name switch
+        {
+            "SUM" => "DOUBLE",
+            "AVG" => "DOUBLE",
+            "COUNT" => "BIGINT",
+            "MAX" => "ANY",
+            "MIN" => "ANY",
+            "TOPK" => "ARRAY",
+            "HISTOGRAM" => "MAP",
+            "TOINT" or "TOINT32" => "INTEGER",
+            "TOLONG" or "TOINT64" => "BIGINT",
+            "TODOUBLE" => "DOUBLE",
+            "TODECIMAL" => "DECIMAL(38, 9)",
+            "TOSTRING" => "VARCHAR",
+            "TOBOOL" or "TOBOOLEAN" => "BOOLEAN",
+            _ => "UNKNOWN"
+        };
+    }
+
+    /// <summary>
     /// カスタムマッピング追加（拡張性のため）
     /// </summary>
     public static void RegisterCustomMapping(string methodName, KsqlFunctionMapping mapping)

--- a/tests/Query/Builders/Functions/KsqlFunctionRegistryTests.cs
+++ b/tests/Query/Builders/Functions/KsqlFunctionRegistryTests.cs
@@ -1,0 +1,23 @@
+using Kafka.Ksql.Linq.Query.Builders.Functions;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Query.Builders.Functions;
+
+public class KsqlFunctionRegistryTests
+{
+    [Theory]
+    [InlineData("Sum", "DOUBLE")]
+    [InlineData("Count", "BIGINT")]
+    [InlineData("Max", "ANY")]
+    [InlineData("Min", "ANY")]
+    [InlineData("TopK", "ARRAY")]
+    [InlineData("Histogram", "MAP")]
+    [InlineData("FooBar", "UNKNOWN")]
+    [InlineData("sum", "DOUBLE")]
+    [InlineData("SuM", "DOUBLE")]
+    public void InferTypeFromMethodName_ReturnsExpected(string methodName, string expected)
+    {
+        var result = KsqlFunctionRegistry.InferTypeFromMethodName(methodName);
+        Assert.Equal(expected, result);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `InferTypeFromMethodName` in `KsqlFunctionRegistry`
- add new xUnit tests covering expected return types

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862a84f2d6083279229f51b002ea59b