### PR TITLE
Add tests for CreateDbTopicAsync

### DIFF
--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -133,6 +133,55 @@ internal class KafkaAdminService : IDisposable
     }
 
     /// <summary>
+    /// DBトピック作成。存在する場合はNo-Op
+    /// </summary>
+    public async Task CreateDbTopicAsync(string topicName, int partitions, short replicationFactor)
+    {
+        if (string.IsNullOrWhiteSpace(topicName))
+            throw new ArgumentException("Topic name is required", nameof(topicName));
+        if (partitions <= 0)
+            throw new ArgumentException("partitions must be > 0", nameof(partitions));
+        if (replicationFactor <= 0)
+            throw new ArgumentException("replicationFactor must be > 0", nameof(replicationFactor));
+
+        var topicsRequest = new TopicCollection { topicName };
+        var topics = await _adminClient.DescribeTopicsAsync(
+            topicsRequest,
+            null,
+            CancellationToken.None);
+        var desc = topics.FirstOrDefault();
+        if (desc != null)
+        {
+            _logger?.LogDebug("DB topic already exists: {Topic}", topicName);
+            return;
+        }
+
+        var spec = new TopicSpecification
+        {
+            Name = topicName,
+            NumPartitions = partitions,
+            ReplicationFactor = replicationFactor
+        };
+
+        try
+        {
+            await _adminClient.CreateTopicsAsync(new[] { spec }, new CreateTopicsOptions { RequestTimeout = TimeSpan.FromSeconds(30) });
+            _logger?.LogInformation("DB topic created: {Topic}", topicName);
+        }
+        catch (CreateTopicsException ex)
+        {
+            var result = ex.Results.FirstOrDefault(r => r.Topic == topicName);
+            if (result?.Error.Code == ErrorCode.TopicAlreadyExists)
+            {
+                _logger?.LogDebug("DB topic already exists (race): {Topic}", topicName);
+                return;
+            }
+
+            throw;
+        }
+    }
+
+    /// <summary>
     /// DLQトピック作成
     /// 設定: DlqTopicConfigurationに基づく動的設定
     /// </summary>

--- a/tests/Infrastructure/KafkaAdminServiceTests.cs
+++ b/tests/Infrastructure/KafkaAdminServiceTests.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Confluent.Kafka;
+using Confluent.Kafka.Admin;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Messaging.Configuration;
 using Kafka.Ksql.Linq.Infrastructure.Admin;
@@ -13,12 +15,44 @@ namespace Kafka.Ksql.Linq.Tests.Infrastructure;
 
 public class KafkaAdminServiceTests
 {
-    private static KafkaAdminService CreateUninitialized(KsqlDslOptions options)
+    private class FakeAdminClient : DispatchProxy
+    {
+        public Func<TopicCollection, DescribeTopicsOptions?, CancellationToken, Task<List<TopicMetadata>>> DescribeHandler { get; set; } = (_, __, ___) => Task.FromResult(new List<TopicMetadata>());
+        public Func<IEnumerable<TopicSpecification>, CreateTopicsOptions?, Task> CreateHandler { get; set; } = (_, __) => Task.CompletedTask;
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            switch (targetMethod?.Name)
+            {
+                case nameof(IAdminClient.CreateTopicsAsync):
+                    return CreateHandler((IEnumerable<TopicSpecification>)args![0]!, (CreateTopicsOptions?)args[1]);
+                case nameof(IAdminClient.DescribeTopicsAsync):
+                    return DescribeHandler(
+                        (TopicCollection)args![0]!,
+                        (DescribeTopicsOptions?)args[1]!,
+                        (CancellationToken)args[2]!);
+                case "Dispose":
+                    return null;
+                case "get_Name":
+                    return "fake";
+                case "get_Handle":
+                    return null!;
+            }
+            throw new NotImplementedException(targetMethod?.Name);
+        }
+    }
+    private static KafkaAdminService CreateUninitialized(KsqlDslOptions options, IAdminClient? adminClient = null)
     {
         var svc = (KafkaAdminService)RuntimeHelpers.GetUninitializedObject(typeof(KafkaAdminService));
         typeof(KafkaAdminService)
             .GetField("_options", BindingFlags.Instance | BindingFlags.NonPublic)!
             .SetValue(svc, options);
+        if (adminClient != null)
+        {
+            typeof(KafkaAdminService)
+                .GetField("_adminClient", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .SetValue(svc, adminClient);
+        }
         return svc;
     }
 
@@ -75,5 +109,66 @@ public class KafkaAdminServiceTests
         Assert.Equal("cert.crt", config.SslCertificateLocation);
         Assert.Equal("key.key", config.SslKeyLocation);
         Assert.Equal("pw", config.SslKeyPassword);
+    }
+
+    [Fact]
+    public async Task CreateDbTopicAsync_Succeeds_WhenTopicDoesNotExist()
+    {
+        var options = new KsqlDslOptions();
+        var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
+        var fake = (FakeAdminClient)proxy!;
+        var created = false;
+        fake.DescribeHandler = (_, __, ___) => Task.FromResult(new List<TopicMetadata>());
+        fake.CreateHandler = (_, __) => { created = true; return Task.CompletedTask; };
+
+        var svc = CreateUninitialized(options, proxy);
+        await svc.CreateDbTopicAsync("t", 1, 1);
+
+        Assert.True(created);
+    }
+
+    [Fact]
+    public async Task CreateDbTopicAsync_NoOp_WhenTopicExists()
+    {
+        var options = new KsqlDslOptions();
+        var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
+        var fake = (FakeAdminClient)proxy!;
+        var meta = (TopicMetadata)RuntimeHelpers.GetUninitializedObject(typeof(TopicMetadata));
+        fake.DescribeHandler = (_, __, ___) => Task.FromResult(new List<TopicMetadata> { meta });
+        var created = false;
+        fake.CreateHandler = (_, __) => { created = true; return Task.CompletedTask; };
+
+        var svc = CreateUninitialized(options, proxy);
+        await svc.CreateDbTopicAsync("t", 1, 1);
+
+        Assert.False(created);
+    }
+
+    [Fact]
+    public async Task CreateDbTopicAsync_Throws_WhenKafkaError()
+    {
+        var options = new KsqlDslOptions();
+        var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
+        var fake = (FakeAdminClient)proxy!;
+        fake.DescribeHandler = (_, __, ___) => Task.FromResult(new List<TopicMetadata>());
+        fake.CreateHandler = (_, __) => throw new KafkaException(new Error(ErrorCode.Local_Transport));
+
+        var svc = CreateUninitialized(options, proxy);
+
+        await Assert.ThrowsAsync<KafkaException>(() => svc.CreateDbTopicAsync("t", 1, 1));
+    }
+
+    [Theory]
+    [InlineData(null, 1, (short)1)]
+    [InlineData("", 1, (short)1)]
+    [InlineData("t", 0, (short)1)]
+    [InlineData("t", 1, (short)0)]
+    public async Task CreateDbTopicAsync_InvalidParameters_Throws(string name, int partitions, short rep)
+    {
+        var options = new KsqlDslOptions();
+        var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
+        var svc = CreateUninitialized(options, proxy);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.CreateDbTopicAsync(name!, partitions, rep));
     }
 }

--- a/tests/Kafka.Ksql.Linq.Tests.csproj
+++ b/tests/Kafka.Ksql.Linq.Tests.csproj
@@ -15,8 +15,9 @@
     <Compile Include="../samples/topic_fluent_api_extension/ManagedTopicExtensions.cs" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-  <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Moq" Version="4.20.62" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   <None Include="appsettings.logging.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Summary
- implement `CreateDbTopicAsync` using `DescribeTopicsAsync` with proper parameters
- adjust dispatch proxy and tests for updated `DescribeTopicsAsync` signature
- fix topic collection instantiation in `CreateDbTopicAsync`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b1f0118c8327be8957fd04d4bb71