### PR TITLE
Fix TopicCollection initialization

### DIFF
--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -144,7 +144,9 @@ internal class KafkaAdminService : IDisposable
         if (replicationFactor <= 0)
             throw new ArgumentException("replicationFactor must be > 0", nameof(replicationFactor));
 
-        var topics = await _adminClient.DescribeTopicsAsync(new[] { topicName });
+        var topics = await AdminClientExtensions.DescribeTopicsAsync(
+            _adminClient,
+            new[] { topicName });
         var desc = topics.FirstOrDefault();
         if (desc != null)
         {

--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -144,22 +144,7 @@ internal class KafkaAdminService : IDisposable
         if (replicationFactor <= 0)
             throw new ArgumentException("replicationFactor must be > 0", nameof(replicationFactor));
 
-        var topicsResult = await _adminClient.DescribeTopicsAsync(
-            TopicCollection.OfTopicNames(new[] { topicName }),
-            null,
-            CancellationToken.None);
-        IEnumerable<TopicMetadata>? topicMeta = null;
-        var prop = typeof(DescribeTopicsResult).GetProperty("Topics");
-        if (prop?.GetValue(topicsResult) is IEnumerable<TopicMetadata> list)
-        {
-            topicMeta = list;
-        }
-        else if (topicsResult is IEnumerable<TopicMetadata> enumerable)
-        {
-            topicMeta = enumerable;
-        }
-        var desc = topicMeta?.FirstOrDefault();
-        if (desc != null)
+        if (TopicExists(topicName, CancellationToken.None))
         {
             _logger?.LogDebug("DB topic already exists: {Topic}", topicName);
             return;

--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -144,8 +144,7 @@ internal class KafkaAdminService : IDisposable
         if (replicationFactor <= 0)
             throw new ArgumentException("replicationFactor must be > 0", nameof(replicationFactor));
 
-        var topics = await _adminClient.DescribeTopicsAsync(
-            TopicCollection.OfTopicNames(new[] { topicName }));
+        var topics = await _adminClient.DescribeTopicsAsync(new[] { topicName });
         var desc = topics.FirstOrDefault();
         if (desc != null)
         {

--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -144,7 +144,9 @@ internal class KafkaAdminService : IDisposable
         if (replicationFactor <= 0)
             throw new ArgumentException("replicationFactor must be > 0", nameof(replicationFactor));
 
-        var topics = await _adminClient.DescribeTopicsAsync(new[] { topicName });
+        var topics = await _adminClient.DescribeTopicsAsync(
+            TopicCollection.OfTopicNames(new[] { topicName }),
+            null);
         var desc = topics.FirstOrDefault();
         if (desc != null)
         {

--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -145,7 +145,7 @@ internal class KafkaAdminService : IDisposable
             throw new ArgumentException("replicationFactor must be > 0", nameof(replicationFactor));
 
         var topics = await _adminClient.DescribeTopicsAsync(
-            new[] { topicName },
+            TopicCollection.OfTopicNames(new[] { topicName }),
             null,
             CancellationToken.None);
         var desc = topics.FirstOrDefault();

--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -146,7 +146,8 @@ internal class KafkaAdminService : IDisposable
 
         var topicsResult = await _adminClient.DescribeTopicsAsync(
             TopicCollection.OfTopicNames(new[] { topicName }),
-            null);
+            null,
+            CancellationToken.None);
         IEnumerable<TopicMetadata>? topicMeta = null;
         var prop = typeof(DescribeTopicsResult).GetProperty("Topics");
         if (prop?.GetValue(topicsResult) is IEnumerable<TopicMetadata> list)

--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -144,8 +144,11 @@ internal class KafkaAdminService : IDisposable
         if (replicationFactor <= 0)
             throw new ArgumentException("replicationFactor must be > 0", nameof(replicationFactor));
 
+        var topicCollection = new TopicCollection();
+        topicCollection.Add(topicName);
+
         var topics = await _adminClient.DescribeTopicsAsync(
-            new TopicCollection(new[] { topicName }),
+            topicCollection,
             null,
             CancellationToken.None);
         var desc = topics.FirstOrDefault();

--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -144,10 +144,20 @@ internal class KafkaAdminService : IDisposable
         if (replicationFactor <= 0)
             throw new ArgumentException("replicationFactor must be > 0", nameof(replicationFactor));
 
-        var topics = await _adminClient.DescribeTopicsAsync(
+        var topicsResult = await _adminClient.DescribeTopicsAsync(
             TopicCollection.OfTopicNames(new[] { topicName }),
             null);
-        var desc = topics.Topics.FirstOrDefault();
+        IEnumerable<TopicMetadata>? topicMeta = null;
+        var prop = typeof(DescribeTopicsResult).GetProperty("Topics");
+        if (prop?.GetValue(topicsResult) is IEnumerable<TopicMetadata> list)
+        {
+            topicMeta = list;
+        }
+        else if (topicsResult is IEnumerable<TopicMetadata> enumerable)
+        {
+            topicMeta = enumerable;
+        }
+        var desc = topicMeta?.FirstOrDefault();
         if (desc != null)
         {
             _logger?.LogDebug("DB topic already exists: {Topic}", topicName);

--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -144,10 +144,7 @@ internal class KafkaAdminService : IDisposable
         if (replicationFactor <= 0)
             throw new ArgumentException("replicationFactor must be > 0", nameof(replicationFactor));
 
-        var topics = await _adminClient.DescribeTopicsAsync(
-            TopicCollection.OfTopicNames(new[] { topicName }),
-            null,
-            CancellationToken.None);
+        var topics = await _adminClient.DescribeTopicsAsync(new[] { topicName });
         var desc = topics.FirstOrDefault();
         if (desc != null)
         {

--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -144,9 +144,10 @@ internal class KafkaAdminService : IDisposable
         if (replicationFactor <= 0)
             throw new ArgumentException("replicationFactor must be > 0", nameof(replicationFactor));
 
-        var topics = await AdminClientExtensions.DescribeTopicsAsync(
-            _adminClient,
-            new[] { topicName });
+        var topics = await _adminClient.DescribeTopicsAsync(
+            TopicCollection.OfTopicNames(new[] { topicName }),
+            null,
+            CancellationToken.None);
         var desc = topics.FirstOrDefault();
         if (desc != null)
         {

--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -144,9 +144,7 @@ internal class KafkaAdminService : IDisposable
         if (replicationFactor <= 0)
             throw new ArgumentException("replicationFactor must be > 0", nameof(replicationFactor));
 
-        var topics = await _adminClient.DescribeTopicsAsync(
-            TopicCollection.OfTopicNames(new[] { topicName }),
-            null);
+        var topics = await _adminClient.DescribeTopicsAsync(new[] { topicName });
         var desc = topics.FirstOrDefault();
         if (desc != null)
         {

--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -144,7 +144,8 @@ internal class KafkaAdminService : IDisposable
         if (replicationFactor <= 0)
             throw new ArgumentException("replicationFactor must be > 0", nameof(replicationFactor));
 
-        var topics = await _adminClient.DescribeTopicsAsync(new[] { topicName });
+        var topics = await _adminClient.DescribeTopicsAsync(
+            TopicCollection.OfTopicNames(new[] { topicName }));
         var desc = topics.FirstOrDefault();
         if (desc != null)
         {

--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -146,8 +146,7 @@ internal class KafkaAdminService : IDisposable
 
         var topics = await _adminClient.DescribeTopicsAsync(
             TopicCollection.OfTopicNames(new[] { topicName }),
-            null,
-            CancellationToken.None);
+            null);
         var desc = topics.FirstOrDefault();
         if (desc != null)
         {

--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -147,7 +147,7 @@ internal class KafkaAdminService : IDisposable
         var topics = await _adminClient.DescribeTopicsAsync(
             TopicCollection.OfTopicNames(new[] { topicName }),
             null);
-        var desc = topics.FirstOrDefault();
+        var desc = topics.Topics.FirstOrDefault();
         if (desc != null)
         {
             _logger?.LogDebug("DB topic already exists: {Topic}", topicName);

--- a/src/Infrastructure/Admin/KafkaAdminService.cs
+++ b/src/Infrastructure/Admin/KafkaAdminService.cs
@@ -144,11 +144,8 @@ internal class KafkaAdminService : IDisposable
         if (replicationFactor <= 0)
             throw new ArgumentException("replicationFactor must be > 0", nameof(replicationFactor));
 
-        var topicCollection = new TopicCollection();
-        topicCollection.Add(topicName);
-
         var topics = await _adminClient.DescribeTopicsAsync(
-            topicCollection,
+            new[] { topicName },
             null,
             CancellationToken.None);
         var desc = topics.FirstOrDefault();

--- a/tests/Infrastructure/KafkaAdminServiceTests.cs
+++ b/tests/Infrastructure/KafkaAdminServiceTests.cs
@@ -17,7 +17,7 @@ public class KafkaAdminServiceTests
 {
     private class FakeAdminClient : DispatchProxy
     {
-        public Func<IEnumerable<string>, Task<List<TopicMetadata>>> DescribeHandler { get; set; } = _ => Task.FromResult(new List<TopicMetadata>());
+        public Func<TopicCollection, DescribeTopicsOptions?, Task<List<TopicMetadata>>> DescribeHandler { get; set; } = (_, __) => Task.FromResult(new List<TopicMetadata>());
         public Func<IEnumerable<TopicSpecification>, CreateTopicsOptions?, Task> CreateHandler { get; set; } = (_, __) => Task.CompletedTask;
 
         protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
@@ -27,7 +27,7 @@ public class KafkaAdminServiceTests
                 case nameof(IAdminClient.CreateTopicsAsync):
                     return CreateHandler((IEnumerable<TopicSpecification>)args![0]!, (CreateTopicsOptions?)args[1]);
                 case nameof(IAdminClient.DescribeTopicsAsync):
-                    return DescribeHandler((IEnumerable<string>)args![0]!);
+                    return DescribeHandler((TopicCollection)args![0]!, (DescribeTopicsOptions?)args[1]!);
                 case "Dispose":
                     return null;
                 case "get_Name":
@@ -115,7 +115,7 @@ public class KafkaAdminServiceTests
         var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
         var fake = (FakeAdminClient)proxy!;
         var created = false;
-        fake.DescribeHandler = _ => Task.FromResult(new List<TopicMetadata>());
+        fake.DescribeHandler = (_, __) => Task.FromResult(new List<TopicMetadata>());
         fake.CreateHandler = (_, __) => { created = true; return Task.CompletedTask; };
 
         var svc = CreateUninitialized(options, proxy);
@@ -131,7 +131,7 @@ public class KafkaAdminServiceTests
         var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
         var fake = (FakeAdminClient)proxy!;
         var meta = (TopicMetadata)RuntimeHelpers.GetUninitializedObject(typeof(TopicMetadata));
-        fake.DescribeHandler = _ => Task.FromResult(new List<TopicMetadata> { meta });
+        fake.DescribeHandler = (_, __) => Task.FromResult(new List<TopicMetadata> { meta });
         var created = false;
         fake.CreateHandler = (_, __) => { created = true; return Task.CompletedTask; };
 
@@ -147,7 +147,7 @@ public class KafkaAdminServiceTests
         var options = new KsqlDslOptions();
         var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
         var fake = (FakeAdminClient)proxy!;
-        fake.DescribeHandler = _ => Task.FromResult(new List<TopicMetadata>());
+        fake.DescribeHandler = (_, __) => Task.FromResult(new List<TopicMetadata>());
         fake.CreateHandler = (_, __) => throw new KafkaException(new Error(ErrorCode.Local_Transport));
 
         var svc = CreateUninitialized(options, proxy);

--- a/tests/Infrastructure/KafkaAdminServiceTests.cs
+++ b/tests/Infrastructure/KafkaAdminServiceTests.cs
@@ -30,9 +30,9 @@ public class KafkaAdminServiceTests
         {
             switch (targetMethod?.Name)
             {
-                case nameof(IAdminClient.CreateTopicsAsync):
+                case "CreateTopicsAsync":
                     return CreateHandler((IEnumerable<TopicSpecification>)args![0]!, (CreateTopicsOptions?)args[1]);
-                case nameof(IAdminClient.DescribeTopicsAsync):
+                case "DescribeTopicsAsync":
                     return DescribeHandler(
                         (TopicCollection)args![0]!,
                         (DescribeTopicsOptions?)args[1]!);

--- a/tests/Infrastructure/KafkaAdminServiceTests.cs
+++ b/tests/Infrastructure/KafkaAdminServiceTests.cs
@@ -10,6 +10,7 @@ using Kafka.Ksql.Linq.Infrastructure.Admin;
 using Xunit;
 using static Kafka.Ksql.Linq.Tests.PrivateAccessor;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Kafka.Ksql.Linq.Tests.Infrastructure;
 

--- a/tests/Infrastructure/KafkaAdminServiceTests.cs
+++ b/tests/Infrastructure/KafkaAdminServiceTests.cs
@@ -22,7 +22,7 @@ public class KafkaAdminServiceTests
         public Func<TimeSpan, Metadata> MetadataHandler { get; set; } = _ =>
         {
             var metadata = (Metadata)RuntimeHelpers.GetUninitializedObject(typeof(Metadata));
-            typeof(Metadata).GetProperty("Topics")?.SetValue(metadata, new List<TopicMetadata>());
+            SetMember(metadata, "Topics", new List<TopicMetadata>());
             return metadata;
         };
         public Func<IEnumerable<TopicSpecification>, CreateTopicsOptions?, Task> CreateHandler { get; set; } = (_, __) => Task.CompletedTask;
@@ -68,7 +68,7 @@ public class KafkaAdminServiceTests
     private static Metadata CreateMetadata(IEnumerable<TopicMetadata> topics)
     {
         var metadata = (Metadata)RuntimeHelpers.GetUninitializedObject(typeof(Metadata));
-        typeof(Metadata).GetProperty("Topics")?.SetValue(metadata, topics.ToList());
+        SetMember(metadata, "Topics", topics.ToList());
         return metadata;
     }
 

--- a/tests/Infrastructure/KafkaAdminServiceTests.cs
+++ b/tests/Infrastructure/KafkaAdminServiceTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using Confluent.Kafka;
 using Confluent.Kafka.Admin;
 using Kafka.Ksql.Linq.Configuration;
@@ -17,7 +16,7 @@ public class KafkaAdminServiceTests
 {
     private class FakeAdminClient : DispatchProxy
     {
-        public Func<TopicCollection, DescribeTopicsOptions?, Task<List<TopicMetadata>>> DescribeHandler { get; set; } = (_, __) => Task.FromResult(new List<TopicMetadata>());
+        public Func<IEnumerable<string>, Task<List<TopicMetadata>>> DescribeHandler { get; set; } = _ => Task.FromResult(new List<TopicMetadata>());
         public Func<IEnumerable<TopicSpecification>, CreateTopicsOptions?, Task> CreateHandler { get; set; } = (_, __) => Task.CompletedTask;
 
         protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
@@ -27,7 +26,7 @@ public class KafkaAdminServiceTests
                 case nameof(IAdminClient.CreateTopicsAsync):
                     return CreateHandler((IEnumerable<TopicSpecification>)args![0]!, (CreateTopicsOptions?)args[1]);
                 case nameof(IAdminClient.DescribeTopicsAsync):
-                    return DescribeHandler((TopicCollection)args![0]!, (DescribeTopicsOptions?)args[1]!);
+                    return DescribeHandler((IEnumerable<string>)args![0]!);
                 case "Dispose":
                     return null;
                 case "get_Name":
@@ -115,7 +114,7 @@ public class KafkaAdminServiceTests
         var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
         var fake = (FakeAdminClient)proxy!;
         var created = false;
-        fake.DescribeHandler = (_, __) => Task.FromResult(new List<TopicMetadata>());
+        fake.DescribeHandler = _ => Task.FromResult(new List<TopicMetadata>());
         fake.CreateHandler = (_, __) => { created = true; return Task.CompletedTask; };
 
         var svc = CreateUninitialized(options, proxy);
@@ -131,7 +130,7 @@ public class KafkaAdminServiceTests
         var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
         var fake = (FakeAdminClient)proxy!;
         var meta = (TopicMetadata)RuntimeHelpers.GetUninitializedObject(typeof(TopicMetadata));
-        fake.DescribeHandler = (_, __) => Task.FromResult(new List<TopicMetadata> { meta });
+        fake.DescribeHandler = _ => Task.FromResult(new List<TopicMetadata> { meta });
         var created = false;
         fake.CreateHandler = (_, __) => { created = true; return Task.CompletedTask; };
 
@@ -147,7 +146,7 @@ public class KafkaAdminServiceTests
         var options = new KsqlDslOptions();
         var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
         var fake = (FakeAdminClient)proxy!;
-        fake.DescribeHandler = (_, __) => Task.FromResult(new List<TopicMetadata>());
+        fake.DescribeHandler = _ => Task.FromResult(new List<TopicMetadata>());
         fake.CreateHandler = (_, __) => throw new KafkaException(new Error(ErrorCode.Local_Transport));
 
         var svc = CreateUninitialized(options, proxy);

--- a/tests/Infrastructure/KafkaAdminServiceTests.cs
+++ b/tests/Infrastructure/KafkaAdminServiceTests.cs
@@ -17,7 +17,7 @@ public class KafkaAdminServiceTests
 {
     private class FakeAdminClient : DispatchProxy
     {
-        public Func<TopicCollection, Task<List<TopicMetadata>>> DescribeHandler { get; set; } = _ => Task.FromResult(new List<TopicMetadata>());
+        public Func<IEnumerable<string>, Task<List<TopicMetadata>>> DescribeHandler { get; set; } = _ => Task.FromResult(new List<TopicMetadata>());
         public Func<IEnumerable<TopicSpecification>, CreateTopicsOptions?, Task> CreateHandler { get; set; } = (_, __) => Task.CompletedTask;
 
         protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
@@ -27,7 +27,7 @@ public class KafkaAdminServiceTests
                 case nameof(IAdminClient.CreateTopicsAsync):
                     return CreateHandler((IEnumerable<TopicSpecification>)args![0]!, (CreateTopicsOptions?)args[1]);
                 case nameof(IAdminClient.DescribeTopicsAsync):
-                    return DescribeHandler((TopicCollection)args![0]!);
+                    return DescribeHandler((IEnumerable<string>)args![0]!);
                 case "Dispose":
                     return null;
                 case "get_Name":

--- a/tests/Infrastructure/KafkaAdminServiceTests.cs
+++ b/tests/Infrastructure/KafkaAdminServiceTests.cs
@@ -16,7 +16,7 @@ public class KafkaAdminServiceTests
 {
     private class FakeAdminClient : DispatchProxy
     {
-        public Func<TopicCollection, DescribeTopicsOptions?, CancellationToken, Task<List<TopicMetadata>>> DescribeHandler { get; set; } = (_, __, ___) => Task.FromResult(new List<TopicMetadata>());
+        public Func<TopicCollection, DescribeTopicsOptions?, Task<List<TopicMetadata>>> DescribeHandler { get; set; } = (_, __) => Task.FromResult(new List<TopicMetadata>());
         public Func<IEnumerable<TopicSpecification>, CreateTopicsOptions?, Task> CreateHandler { get; set; } = (_, __) => Task.CompletedTask;
 
         protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
@@ -28,8 +28,7 @@ public class KafkaAdminServiceTests
                 case nameof(IAdminClient.DescribeTopicsAsync):
                     return DescribeHandler(
                         (TopicCollection)args![0]!,
-                        (DescribeTopicsOptions?)args[1]!,
-                        (CancellationToken)args[2]!);
+                        (DescribeTopicsOptions?)args[1]!);
                 case "Dispose":
                     return null;
                 case "get_Name":
@@ -117,7 +116,7 @@ public class KafkaAdminServiceTests
         var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
         var fake = (FakeAdminClient)proxy!;
         var created = false;
-        fake.DescribeHandler = (_, __, ___) => Task.FromResult(new List<TopicMetadata>());
+        fake.DescribeHandler = (_, __) => Task.FromResult(new List<TopicMetadata>());
         fake.CreateHandler = (_, __) => { created = true; return Task.CompletedTask; };
 
         var svc = CreateUninitialized(options, proxy);
@@ -133,7 +132,7 @@ public class KafkaAdminServiceTests
         var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
         var fake = (FakeAdminClient)proxy!;
         var meta = (TopicMetadata)RuntimeHelpers.GetUninitializedObject(typeof(TopicMetadata));
-        fake.DescribeHandler = (_, __, ___) => Task.FromResult(new List<TopicMetadata> { meta });
+        fake.DescribeHandler = (_, __) => Task.FromResult(new List<TopicMetadata> { meta });
         var created = false;
         fake.CreateHandler = (_, __) => { created = true; return Task.CompletedTask; };
 
@@ -149,7 +148,7 @@ public class KafkaAdminServiceTests
         var options = new KsqlDslOptions();
         var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
         var fake = (FakeAdminClient)proxy!;
-        fake.DescribeHandler = (_, __, ___) => Task.FromResult(new List<TopicMetadata>());
+        fake.DescribeHandler = (_, __) => Task.FromResult(new List<TopicMetadata>());
         fake.CreateHandler = (_, __) => throw new KafkaException(new Error(ErrorCode.Local_Transport));
 
         var svc = CreateUninitialized(options, proxy);

--- a/tests/Infrastructure/KafkaAdminServiceTests.cs
+++ b/tests/Infrastructure/KafkaAdminServiceTests.cs
@@ -17,7 +17,7 @@ public class KafkaAdminServiceTests
 {
     private class FakeAdminClient : DispatchProxy
     {
-        public Func<TopicCollection, DescribeTopicsOptions?, CancellationToken, Task<List<TopicMetadata>>> DescribeHandler { get; set; } = (_, __, ___) => Task.FromResult(new List<TopicMetadata>());
+        public Func<IEnumerable<string>, Task<List<TopicMetadata>>> DescribeHandler { get; set; } = _ => Task.FromResult(new List<TopicMetadata>());
         public Func<IEnumerable<TopicSpecification>, CreateTopicsOptions?, Task> CreateHandler { get; set; } = (_, __) => Task.CompletedTask;
 
         protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
@@ -27,10 +27,7 @@ public class KafkaAdminServiceTests
                 case nameof(IAdminClient.CreateTopicsAsync):
                     return CreateHandler((IEnumerable<TopicSpecification>)args![0]!, (CreateTopicsOptions?)args[1]);
                 case nameof(IAdminClient.DescribeTopicsAsync):
-                    return DescribeHandler(
-                        (TopicCollection)args![0]!,
-                        (DescribeTopicsOptions?)args[1]!,
-                        (CancellationToken)args[2]!);
+                    return DescribeHandler((IEnumerable<string>)args![0]!);
                 case "Dispose":
                     return null;
                 case "get_Name":
@@ -118,7 +115,7 @@ public class KafkaAdminServiceTests
         var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
         var fake = (FakeAdminClient)proxy!;
         var created = false;
-        fake.DescribeHandler = (_, __, ___) => Task.FromResult(new List<TopicMetadata>());
+        fake.DescribeHandler = _ => Task.FromResult(new List<TopicMetadata>());
         fake.CreateHandler = (_, __) => { created = true; return Task.CompletedTask; };
 
         var svc = CreateUninitialized(options, proxy);
@@ -134,7 +131,7 @@ public class KafkaAdminServiceTests
         var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
         var fake = (FakeAdminClient)proxy!;
         var meta = (TopicMetadata)RuntimeHelpers.GetUninitializedObject(typeof(TopicMetadata));
-        fake.DescribeHandler = (_, __, ___) => Task.FromResult(new List<TopicMetadata> { meta });
+        fake.DescribeHandler = _ => Task.FromResult(new List<TopicMetadata> { meta });
         var created = false;
         fake.CreateHandler = (_, __) => { created = true; return Task.CompletedTask; };
 
@@ -150,7 +147,7 @@ public class KafkaAdminServiceTests
         var options = new KsqlDslOptions();
         var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
         var fake = (FakeAdminClient)proxy!;
-        fake.DescribeHandler = (_, __, ___) => Task.FromResult(new List<TopicMetadata>());
+        fake.DescribeHandler = _ => Task.FromResult(new List<TopicMetadata>());
         fake.CreateHandler = (_, __) => throw new KafkaException(new Error(ErrorCode.Local_Transport));
 
         var svc = CreateUninitialized(options, proxy);

--- a/tests/Infrastructure/KafkaAdminServiceTests.cs
+++ b/tests/Infrastructure/KafkaAdminServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Confluent.Kafka;
+using Confluent.Kafka.Admin;
 using Kafka.Ksql.Linq.Configuration;
 using Kafka.Ksql.Linq.Messaging.Configuration;
 using Kafka.Ksql.Linq.Infrastructure.Admin;

--- a/tests/Infrastructure/KafkaAdminServiceTests.cs
+++ b/tests/Infrastructure/KafkaAdminServiceTests.cs
@@ -16,7 +16,7 @@ public class KafkaAdminServiceTests
 {
     private class FakeAdminClient : DispatchProxy
     {
-        public Func<IEnumerable<string>, Task<List<TopicMetadata>>> DescribeHandler { get; set; } = _ => Task.FromResult(new List<TopicMetadata>());
+        public Func<TopicCollection, DescribeTopicsOptions?, CancellationToken, Task<List<TopicMetadata>>> DescribeHandler { get; set; } = (_, __, ___) => Task.FromResult(new List<TopicMetadata>());
         public Func<IEnumerable<TopicSpecification>, CreateTopicsOptions?, Task> CreateHandler { get; set; } = (_, __) => Task.CompletedTask;
 
         protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
@@ -26,7 +26,10 @@ public class KafkaAdminServiceTests
                 case nameof(IAdminClient.CreateTopicsAsync):
                     return CreateHandler((IEnumerable<TopicSpecification>)args![0]!, (CreateTopicsOptions?)args[1]);
                 case nameof(IAdminClient.DescribeTopicsAsync):
-                    return DescribeHandler((IEnumerable<string>)args![0]!);
+                    return DescribeHandler(
+                        (TopicCollection)args![0]!,
+                        (DescribeTopicsOptions?)args[1]!,
+                        (CancellationToken)args[2]!);
                 case "Dispose":
                     return null;
                 case "get_Name":
@@ -114,7 +117,7 @@ public class KafkaAdminServiceTests
         var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
         var fake = (FakeAdminClient)proxy!;
         var created = false;
-        fake.DescribeHandler = _ => Task.FromResult(new List<TopicMetadata>());
+        fake.DescribeHandler = (_, __, ___) => Task.FromResult(new List<TopicMetadata>());
         fake.CreateHandler = (_, __) => { created = true; return Task.CompletedTask; };
 
         var svc = CreateUninitialized(options, proxy);
@@ -130,7 +133,7 @@ public class KafkaAdminServiceTests
         var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
         var fake = (FakeAdminClient)proxy!;
         var meta = (TopicMetadata)RuntimeHelpers.GetUninitializedObject(typeof(TopicMetadata));
-        fake.DescribeHandler = _ => Task.FromResult(new List<TopicMetadata> { meta });
+        fake.DescribeHandler = (_, __, ___) => Task.FromResult(new List<TopicMetadata> { meta });
         var created = false;
         fake.CreateHandler = (_, __) => { created = true; return Task.CompletedTask; };
 
@@ -146,7 +149,7 @@ public class KafkaAdminServiceTests
         var options = new KsqlDslOptions();
         var proxy = DispatchProxy.Create<IAdminClient, FakeAdminClient>();
         var fake = (FakeAdminClient)proxy!;
-        fake.DescribeHandler = _ => Task.FromResult(new List<TopicMetadata>());
+        fake.DescribeHandler = (_, __, ___) => Task.FromResult(new List<TopicMetadata>());
         fake.CreateHandler = (_, __) => throw new KafkaException(new Error(ErrorCode.Local_Transport));
 
         var svc = CreateUninitialized(options, proxy);

--- a/tests/Infrastructure/KafkaAdminServiceTests.cs
+++ b/tests/Infrastructure/KafkaAdminServiceTests.cs
@@ -17,7 +17,7 @@ public class KafkaAdminServiceTests
 {
     private class FakeAdminClient : DispatchProxy
     {
-        public Func<IEnumerable<string>, Task<List<TopicMetadata>>> DescribeHandler { get; set; } = _ => Task.FromResult(new List<TopicMetadata>());
+        public Func<TopicCollection, Task<List<TopicMetadata>>> DescribeHandler { get; set; } = _ => Task.FromResult(new List<TopicMetadata>());
         public Func<IEnumerable<TopicSpecification>, CreateTopicsOptions?, Task> CreateHandler { get; set; } = (_, __) => Task.CompletedTask;
 
         protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
@@ -27,7 +27,7 @@ public class KafkaAdminServiceTests
                 case nameof(IAdminClient.CreateTopicsAsync):
                     return CreateHandler((IEnumerable<TopicSpecification>)args![0]!, (CreateTopicsOptions?)args[1]);
                 case nameof(IAdminClient.DescribeTopicsAsync):
-                    return DescribeHandler((IEnumerable<string>)args![0]!);
+                    return DescribeHandler((TopicCollection)args![0]!);
                 case "Dispose":
                     return null;
                 case "get_Name":


### PR DESCRIPTION
## Summary
- correct `TopicCollection` usage in KafkaAdminService

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b7e1f750832796cc9436c54b55d9