### PR TITLE
Add case-insensitive tests for InferTypeFromMethodName

### DIFF
--- a/tests/Query/Builders/Functions/KsqlFunctionRegistryTests.cs
+++ b/tests/Query/Builders/Functions/KsqlFunctionRegistryTests.cs
@@ -14,8 +14,7 @@ public class KsqlFunctionRegistryTests
     [InlineData("TopK", "ARRAY")]
     [InlineData("Histogram", "MAP")]
     [InlineData("FooBar", "UNKNOWN")]
-    [InlineData("sum", "DOUBLE")]
-    [InlineData("SuM", "DOUBLE")]
+    [InlineData("sUm", "DOUBLE")]
     public void InferTypeFromMethodName_ReturnsExpected(string methodName, string expected)
     {
         var result = KsqlFunctionRegistry.InferTypeFromMethodName(methodName);


### PR DESCRIPTION
## Summary
- simplify `InferTypeFromMethodName` unit test
- cover expected return types for common function names and case variations

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68631542abe4832784e370adb0d8dba6