### PR TITLE
Add SubscribeAsync flow tests

### DIFF
--- a/tests/Infrastructure/Consumer/KafkaConsumerManagerTests.cs
+++ b/tests/Infrastructure/Consumer/KafkaConsumerManagerTests.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Kafka.Ksql.Linq.Messaging.Abstractions;
+using Kafka.Ksql.Linq.Messaging.Consumers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Kafka.Ksql.Linq.Tests.Infrastructure.Consumer;
+
+public class KafkaConsumerManagerTests
+{
+    private class SampleEntity
+    {
+        [Kafka.Ksql.Linq.Core.Abstractions.Key]
+        public int Id { get; set; }
+    }
+
+    private class StubConsumer : IKafkaConsumer<SampleEntity, object>
+    {
+        private readonly Func<CancellationToken, IAsyncEnumerable<KafkaMessage<SampleEntity, object>>> _consume;
+        public string TopicName { get; }
+        public StubConsumer(string topic, Func<CancellationToken, IAsyncEnumerable<KafkaMessage<SampleEntity, object>>> consume)
+        {
+            TopicName = topic;
+            _consume = consume;
+        }
+        public IAsyncEnumerable<KafkaMessage<SampleEntity, object>> ConsumeAsync(CancellationToken cancellationToken = default) => _consume(cancellationToken);
+        public Task<KafkaBatch<SampleEntity, object>> ConsumeBatchAsync(KafkaBatchOptions options, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public Task CommitAsync() => Task.CompletedTask;
+        public Task SeekAsync(TopicPartitionOffset offset) => Task.CompletedTask;
+        public List<TopicPartition> GetAssignedPartitions() => new();
+        public void Dispose() { }
+    }
+
+    private static KafkaConsumerManager CreateManager(IKafkaConsumer<SampleEntity, object> consumer, ILogger? logger)
+    {
+        var manager = (KafkaConsumerManager)RuntimeHelpers.GetUninitializedObject(typeof(KafkaConsumerManager));
+        typeof(KafkaConsumerManager).GetField("_consumers", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(manager, new ConcurrentDictionary<Type, object>(new[] { new KeyValuePair<Type, object>(typeof(SampleEntity), consumer) }));
+        typeof(KafkaConsumerManager).GetField("_serializationManagers", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(manager, new ConcurrentDictionary<Type, object>());
+        typeof(KafkaConsumerManager).GetField("_logger", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(manager, logger);
+        typeof(KafkaConsumerManager).GetField("_loggerFactory", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(manager, new NullLoggerFactory());
+        typeof(KafkaConsumerManager).GetField("_options", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(manager, new Kafka.Ksql.Linq.Configuration.KsqlDslOptions());
+        typeof(KafkaConsumerManager).GetField("_dlqProducer", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(manager, RuntimeHelpers.GetUninitializedObject(typeof(Kafka.Ksql.Linq.Messaging.Producers.DlqProducer)));
+        typeof(KafkaConsumerManager).GetField("_schemaRegistryClient", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(manager, new Lazy<Confluent.SchemaRegistry.ISchemaRegistryClient>(() => new Mock<Confluent.SchemaRegistry.ISchemaRegistryClient>().Object));
+        return manager;
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_CallsHandlerOnce()
+    {
+        async IAsyncEnumerable<KafkaMessage<SampleEntity, object>> OneMessage([EnumeratorCancellation] CancellationToken token)
+        {
+            yield return new KafkaMessage<SampleEntity, object> { Value = new SampleEntity { Id = 1 } };
+        }
+        var consumer = new StubConsumer("topic", OneMessage);
+        var manager = CreateManager(consumer, NullLogger.Instance);
+        var tcs = new TaskCompletionSource<bool>();
+        int count = 0;
+
+        await manager.SubscribeAsync<SampleEntity>(async (e, ctx) => { count++; tcs.SetResult(true); await Task.CompletedTask; }, cancellationToken: CancellationToken.None);
+        await Task.WhenAny(tcs.Task, Task.Delay(1000));
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_HandlerThrows_LogsAndContinues()
+    {
+        async IAsyncEnumerable<KafkaMessage<SampleEntity, object>> TwoMessages([EnumeratorCancellation] CancellationToken token)
+        {
+            yield return new KafkaMessage<SampleEntity, object> { Value = new SampleEntity { Id = 1 } };
+            yield return new KafkaMessage<SampleEntity, object> { Value = new SampleEntity { Id = 2 } };
+        }
+        var consumer = new StubConsumer("topic", TwoMessages);
+        var loggerMock = new Mock<ILogger>();
+        var manager = CreateManager(consumer, loggerMock.Object);
+        var tcs = new TaskCompletionSource<bool>();
+        int count = 0;
+
+        await manager.SubscribeAsync<SampleEntity>(async (e, ctx) =>
+        {
+            count++;
+            if (count == 1) throw new InvalidOperationException("fail");
+            tcs.SetResult(true);
+        }, cancellationToken: CancellationToken.None);
+
+        await Task.WhenAny(tcs.Task, Task.Delay(1000));
+
+        loggerMock.Verify(l => l.Log(
+            LogLevel.Error,
+            It.IsAny<EventId>(),
+            It.IsAny<It.IsAnyType>(),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.AtLeastOnce);
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_ConsumeError_LogsAndStops()
+    {
+        async IAsyncEnumerable<KafkaMessage<SampleEntity, object>> Throwing([EnumeratorCancellation] CancellationToken token)
+        {
+            await Task.Yield();
+            throw new Exception("consume error");
+            yield break;
+        }
+        var consumer = new StubConsumer("topic", Throwing);
+        var loggerMock = new Mock<ILogger>();
+        var manager = CreateManager(consumer, loggerMock.Object);
+
+        await manager.SubscribeAsync<SampleEntity>((e, ctx) => Task.CompletedTask, cancellationToken: CancellationToken.None);
+        await Task.Delay(100); // allow background task to run
+
+        loggerMock.Verify(l => l.Log(
+            LogLevel.Error,
+            It.IsAny<EventId>(),
+            It.IsAny<It.IsAnyType>(),
+            It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task SubscribeAsync_Cancellation_StopsLoop()
+    {
+        async IAsyncEnumerable<KafkaMessage<SampleEntity, object>> Infinite([EnumeratorCancellation] CancellationToken token)
+        {
+            int i = 0;
+            while (true)
+            {
+                token.ThrowIfCancellationRequested();
+                yield return new KafkaMessage<SampleEntity, object> { Value = new SampleEntity { Id = i++ } };
+                await Task.Delay(10, token);
+            }
+        }
+        var consumer = new StubConsumer("topic", Infinite);
+        var manager = CreateManager(consumer, NullLogger.Instance);
+        var cts = new CancellationTokenSource();
+        var tcs = new TaskCompletionSource<bool>();
+        int count = 0;
+
+        await manager.SubscribeAsync<SampleEntity>(async (e, ctx) =>
+        {
+            count++;
+            tcs.SetResult(true);
+            cts.Cancel();
+            await Task.CompletedTask;
+        }, cancellationToken: cts.Token);
+
+        await Task.WhenAny(tcs.Task, Task.Delay(1000));
+        await Task.Delay(100); // give time for cancellation
+        Assert.Equal(1, count);
+    }
+}

--- a/tests/Infrastructure/Consumer/KafkaConsumerManagerTests.cs
+++ b/tests/Infrastructure/Consumer/KafkaConsumerManagerTests.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using Confluent.Kafka;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Abstractions;
+using Kafka.Ksql.Linq.Messaging.Producers.Core;
+using Kafka.Ksql.Linq.Configuration.Abstractions;
 using Kafka.Ksql.Linq.Messaging.Consumers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;


### PR DESCRIPTION
## Summary
- add unit tests for `KafkaConsumerManager.SubscribeAsync` verifying handler execution, exception and cancellation handling

## Testing
- `dotnet test tests/Kafka.Ksql.Linq.Tests.csproj --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686319fdcbb08327957659616095a3b4