### PR TITLE
Update API reference and review

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -24,10 +24,11 @@
 | DSL メソッド | 説明 | 戻り値型 | 対象レイヤ | 実装状態 |
 |---------------|------|-----------|------------|---------|
 | `.Where(predicate)` | 条件フィルタ | `IEventSet<T>` | Stream/Table | ✅ |
-| `.Window(int \| TimeSpan)` | タイムウィンドウ指定 | `IQueryable<T>` | Stream | ✅ |
+| `.Window(WindowDef \| TimeSpan)` | タイムウィンドウ指定 | `IQueryable<T>` | Stream | ✅ |
 | `.GroupBy(...)` | グループ化および集約 | `IEventSet<IGrouping<TKey, T>>` | Stream/Table | ✅ |
 | `.OnError(ErrorAction)` | エラー処理方針指定 | `EventSet<T>` | Stream | ✅ |
 | `.WithRetry(int)` | リトライ設定 | `EventSet<T>` | Stream | ✅ |
+| `.StartErrorHandling()` | エラーチェーン開始 | `IErrorHandlingChain<T>` | Stream | ✅ |
 | `.WithManualCommit()` | 手動コミットモード切替 | `IEntityBuilder<T>` | Subscription | ✅ |
 
 - `ToList`/`ToListAsync` は Pull Query として実行されます【F:src/Query/Pipeline/DMLQueryGenerator.cs†L27-L34】。
@@ -57,6 +58,8 @@
 | `KsqlDslOptions` | DLQ 設定や ValidationMode など DSL 全体の構成を保持 | ✅ |
 | `ModelBuilder` | POCO から `EntityModel` を構築するビルダー | ✅ |
 | `KafkaAdminService` | DLQ トピック作成などの管理操作 | ✅ |
+| `AvroOperationRetrySettings` | Avro操作ごとのリトライ設定 | ✅ |
+| `AvroRetryPolicy` | リトライ回数や遅延などの詳細ポリシー | ✅ |
 
 `KsqlDslOptions.DlqTopicName` は既定で `"dead.letter.queue"` です【F:src/Configuration/KsqlDslOptions.cs†L31-L34】。
 
@@ -77,12 +80,16 @@
 | `ReadyStateMonitor` | トピック同期状態の監視 | ✅ |
 | `StateStoreBinding` | Kafka トピックと StateStore の双方向バインディング | ✅ |
 | `SchemaRegistryClient` | スキーマ管理クライアント | ✅ |
+| `ResilientAvroSerializerManager` | Avro操作のリトライ管理 | ✅ |
+| `WindowFinalizationManager` | Window最終化処理のタイマー管理 | ✅ |
 
 ## 各 API の備考
 
 - `IEventSet<T>.WithRetry()` の実装例は `EventSetErrorHandlingExtensions.cs` にあります【F:src/EventSetErrorHandlingExtensions.cs†L120-L156】。
 - `OnError` の拡張は同ファイルで提供されています【F:src/EventSetErrorHandlingExtensions.cs†L14-L37】。
 - 手動コミットの利用例は [manual_commit.md](manual_commit.md) を参照してください。
+- `StartErrorHandling()` → `.Map()` → `.WithRetry()` の流れで細かいエラー処理を構築できます。
+- `AvroOperationRetrySettings` で SchemaRegistry 操作のリトライ方針を制御します【F:src/Configuration/Options/AvroOperationRetrySettings.cs†L8-L33】。
 
 ## 実装・設計整合性一覧
 

--- a/reports/20250701_223827.txt
+++ b/reports/20250701_223827.txt
@@ -1,0 +1,20 @@
+品質管理レポート (鏡花)
+日時: Tue Jul  1 22:38:39 UTC 2025
+
+対象ファイル: docs/api_reference.md
+
+## 1. ソースとの整合性確認
+- 新たに追加された `StartErrorHandling` チェーンや `WindowDef` の記述を確認。実装ファイル `src/EventSetErrorHandlingExtensions.cs` 等で定義されたメソッドと一致。
+- `AvroOperationRetrySettings` および `AvroRetryPolicy` の項目を追記し、`src/Configuration/Options` 内の実装と整合。
+- `ResilientAvroSerializerManager` など内部処理クラスも表に反映し、名称差異なし。
+
+## 2. ドキュメント品質評価
+- DSL一覧に戻り値型と目的が明示されており、利用者がチェーンの流れを把握しやすい。
+- 構成オプションや内部機構の表形式が維持され、追記箇所も統一された書式で読みやすい。
+- ただし `implement_status.md` へのリンクが旧フォルダ(`docs/old`)となっている点は要整理。
+
+## 3. 利用者目線の気付き
+- `StartErrorHandling()` のサンプルフローを備考に記載したため、初学者が使い方を掴みやすくなった。
+- `AvroOperationRetrySettings` の説明は概要に留まっている。具体例が今後求められる可能性あり。
+
+以上、現状の更新内容は実装と概ね一致しており、利用者が参照するAPI情報として十分実用的と判断します。


### PR DESCRIPTION
## Summary
- update API Reference with new DSL entry `StartErrorHandling`, WindowDef usage, and new configuration/monitor classes
- add `AvroOperationRetrySettings` and `AvroRetryPolicy` to configuration table
- document internal classes `ResilientAvroSerializerManager` and `WindowFinalizationManager`
- add usage notes in the remarks
- include quality review report

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864623769f88327b16b6b47dcfc9d08