### PR TITLE
Add expanded example suite

### DIFF
--- a/examples/api-showcase/ApiShowcase.csproj
+++ b/examples/api-showcase/ApiShowcase.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Kafka.Ksql.Linq.csproj" />
+  </ItemGroup>
+</Project>

--- a/examples/api-showcase/Program.cs
+++ b/examples/api-showcase/Program.cs
@@ -1,0 +1,66 @@
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+using System.Linq;
+[Topic("api-showcase")]
+public class ApiMessage
+{
+    [Key]
+    public int Id { get; set; }
+
+    [AvroTimestamp]
+    public DateTime CreatedAt { get; set; }
+
+    public string Category { get; set; } = string.Empty;
+}
+
+public class ApiContext : KsqlContext
+{
+    protected override void OnModelCreating(IModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ApiMessage>();
+    }
+}
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var context = KsqlContextBuilder.Create()
+            .UseConfiguration(configuration)
+            .UseSchemaRegistry(configuration["KsqlDsl:SchemaRegistry:Url"]!)
+            .EnableLogging(LoggerFactory.Create(builder => builder.AddConsole()))
+            .BuildContext<ApiContext>();
+
+        var message = new ApiMessage
+        {
+            Id = Random.Shared.Next(),
+            CreatedAt = DateTime.UtcNow,
+            Category = "A"
+        };
+
+        await context.Set<ApiMessage>().AddAsync(message);
+        // wait briefly for message to be published
+        await Task.Delay(500);
+
+        await context.Set<ApiMessage>()
+            .Where(m => m.Category == "A")
+            .GroupBy(m => m.Category)
+            .Select(g => new { g.Key, Count = g.Count() })
+            .OnError(ErrorAction.Skip)
+            .WithRetry(2)
+            .ForEachAsync(r =>
+            {
+                Console.WriteLine($"Category {r.Key}: {r.Count}");
+                return Task.CompletedTask;
+            });
+    }
+}

--- a/examples/api-showcase/README.md
+++ b/examples/api-showcase/README.md
@@ -1,0 +1,24 @@
+# API Showcase Example
+
+This program exercises multiple DSL features including `Where`, `GroupBy`,
+`Select`, `OnError`, and `WithRetry`. Records with `Category` "A" are
+aggregated and the count printed.
+
+See the API reference in [api_reference.md](../../docs/api_reference.md) for
+details on each method.
+
+## Prerequisites
+- .NET 8 SDK
+- Docker
+
+## Run Steps
+1. Start the containers:
+   ```bash
+   docker-compose up -d
+   ```
+2. Execute the sample:
+   ```bash
+   dotnet run --project .
+   ```
+
+Enable debug logging to inspect the generated ksql queries.

--- a/examples/api-showcase/appsettings.json
+++ b/examples/api-showcase/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Kafka.Ksql.Linq.Query": "Debug"
+    }
+  },
+  "KsqlDsl": {
+    "Common": {
+      "BootstrapServers": "localhost:9092",
+      "ClientId": "hello-app"
+    },
+    "SchemaRegistry": {
+      "Url": "http://localhost:8085"
+    }
+  }
+}

--- a/examples/api-showcase/docker-compose.yml
+++ b/examples/api-showcase/docker-compose.yml
@@ -1,0 +1,55 @@
+version: '3.7'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.3
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:7.4.3
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:9093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+    healthcheck:
+      test: ["CMD", "kafka-topics", "--bootstrap-server", "localhost:9092", "--list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  ksqldb-server:
+    image: confluentinc/ksqldb-server:0.29.0
+    depends_on:
+      kafka:
+        condition: service_healthy
+    ports:
+      - "8088:8088"
+    environment:
+      KSQL_CONFIG_DIR: "/etc/ksql"
+      KSQL_BOOTSTRAP_SERVERS: "kafka:9092"
+      KSQL_LISTENERS: "http://0.0.0.0:8088"
+      KSQL_KSQL_SERVICE_ID: "ksql_service_1"
+      KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
+      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
+      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
+
+  ksqldb-cli:
+    image: confluentinc/ksqldb-cli:0.29.0
+    depends_on:
+      - ksqldb-server
+    entrypoint: /bin/sh
+    tty: true

--- a/examples/basic-produce-consume/BasicProduceConsume.csproj
+++ b/examples/basic-produce-consume/BasicProduceConsume.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Kafka.Ksql.Linq.csproj" />
+  </ItemGroup>
+</Project>

--- a/examples/basic-produce-consume/Program.cs
+++ b/examples/basic-produce-consume/Program.cs
@@ -1,0 +1,59 @@
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+[Topic("basic-produce-consume")]
+public class BasicMessage
+{
+    [Key]
+    public int Id { get; set; }
+
+    [AvroTimestamp]
+    public DateTime CreatedAt { get; set; }
+
+    public string Text { get; set; } = string.Empty;
+}
+
+public class BasicContext : KsqlContext
+{
+    protected override void OnModelCreating(IModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<BasicMessage>();
+    }
+}
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var context = KsqlContextBuilder.Create()
+            .UseConfiguration(configuration)
+            .UseSchemaRegistry(configuration["KsqlDsl:SchemaRegistry:Url"]!)
+            .EnableLogging(LoggerFactory.Create(builder => builder.AddConsole()))
+            .BuildContext<BasicContext>();
+
+        var message = new BasicMessage
+        {
+            Id = Random.Shared.Next(),
+            CreatedAt = DateTime.UtcNow,
+            Text = "Basic Flow"
+        };
+
+        await context.Set<BasicMessage>().AddAsync(message);
+        // wait briefly for message to be published
+        await Task.Delay(500);
+
+        await context.Set<BasicMessage>().ForEachAsync(m =>
+        {
+            Console.WriteLine($"Consumed message: {m.Text}");
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/examples/basic-produce-consume/README.md
+++ b/examples/basic-produce-consume/README.md
@@ -1,0 +1,25 @@
+# Basic Produce and Consume Example
+
+This sample pairs a simple producer and consumer using **Kafka.Ksql.Linq**.
+`Program.cs` registers `BasicMessage` with `[Topic]` and demonstrates
+sending a record then retrieving it with `ForEachAsync`.
+
+This example corresponds to [getting-started.md](../../docs/getting-started.md)
+section *3. POCO属性ベースDSL設計ルール*.
+
+## Prerequisites
+- .NET 8 SDK
+- Docker
+
+## Run Steps
+1. Start Kafka and ksqlDB:
+   ```bash
+   docker-compose up -d
+   ```
+2. Run the program:
+   ```bash
+   dotnet run --project .
+   ```
+
+Query details are visible in debug logs when `LogLevel: Debug` is enabled
+in `appsettings.json`.

--- a/examples/basic-produce-consume/appsettings.json
+++ b/examples/basic-produce-consume/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Kafka.Ksql.Linq.Query": "Debug"
+    }
+  },
+  "KsqlDsl": {
+    "Common": {
+      "BootstrapServers": "localhost:9092",
+      "ClientId": "hello-app"
+    },
+    "SchemaRegistry": {
+      "Url": "http://localhost:8085"
+    }
+  }
+}

--- a/examples/basic-produce-consume/docker-compose.yml
+++ b/examples/basic-produce-consume/docker-compose.yml
@@ -1,0 +1,55 @@
+version: '3.7'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.3
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:7.4.3
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:9093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+    healthcheck:
+      test: ["CMD", "kafka-topics", "--bootstrap-server", "localhost:9092", "--list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  ksqldb-server:
+    image: confluentinc/ksqldb-server:0.29.0
+    depends_on:
+      kafka:
+        condition: service_healthy
+    ports:
+      - "8088:8088"
+    environment:
+      KSQL_CONFIG_DIR: "/etc/ksql"
+      KSQL_BOOTSTRAP_SERVERS: "kafka:9092"
+      KSQL_LISTENERS: "http://0.0.0.0:8088"
+      KSQL_KSQL_SERVICE_ID: "ksql_service_1"
+      KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
+      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
+      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
+
+  ksqldb-cli:
+    image: confluentinc/ksqldb-cli:0.29.0
+    depends_on:
+      - ksqldb-server
+    entrypoint: /bin/sh
+    tty: true

--- a/examples/configuration-mapping/ConfigurationMapping.csproj
+++ b/examples/configuration-mapping/ConfigurationMapping.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Kafka.Ksql.Linq.csproj" />
+  </ItemGroup>
+</Project>

--- a/examples/configuration-mapping/Program.cs
+++ b/examples/configuration-mapping/Program.cs
@@ -1,0 +1,60 @@
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+[Topic("hello-world")]
+public class HelloMessage
+{
+    [Key]
+    public int Id { get; set; }
+
+    [AvroTimestamp]
+    public DateTime CreatedAt { get; set; }
+
+    public string Text { get; set; } = string.Empty;
+}
+
+public class HelloKafkaContext : KsqlContext
+{
+    protected override void OnModelCreating(IModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<HelloMessage>();
+    }
+}
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        var configuration = new ConfigurationBuilder()
+            // replace with `appsettings.Development.json` or `appsettings.Production.json`
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var context = KsqlContextBuilder.Create()
+            .UseConfiguration(configuration)
+            .UseSchemaRegistry(configuration["KsqlDsl:SchemaRegistry:Url"]!)
+            .EnableLogging(LoggerFactory.Create(builder => builder.AddConsole()))
+            .BuildContext<HelloKafkaContext>();
+
+        var message = new HelloMessage
+        {
+            Id = Random.Shared.Next(),
+            CreatedAt = DateTime.UtcNow,
+            Text = "Hello World"
+        };
+
+        await context.Set<HelloMessage>().AddAsync(message);
+        // wait briefly for message to be published
+        await Task.Delay(500);
+
+        await context.Set<HelloMessage>().ForEachAsync(m =>
+        {
+            Console.WriteLine($"Received: {m.Text}");
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/examples/configuration-mapping/README.md
+++ b/examples/configuration-mapping/README.md
@@ -1,0 +1,29 @@
+# Configuration Example
+
+This sample demonstrates how to switch logging output between development and production environments using **Kafka.Ksql.Linq**.
+The default `appsettings.json` is tuned for debugging with `LogLevel:Debug`.
+`Program.cs` is copied from the Hello World example. `appsettings.Development.json` enables verbose logging for development, while
+`appsettings.Production.json` suppresses most output for a quieter runtime. Replace the file referenced in `Program.cs` as needed before running.
+`docker-compose.yml` provides the required Kafka and ksqlDB services.
+
+## Prerequisites
+
+- .NET 8 SDK
+- Docker (for Kafka and ksqlDB)
+
+## Setup
+
+1. Start the local Kafka stack:
+   ```bash
+   docker-compose up -d
+   ```
+2. Run your application with the desired configuration, for example:
+   ```bash
+   dotnet run --no-build --environment Development
+   ```
+
+## Design Document Reference
+
+- [ロギングとクエリ可視化](../../docs/oss_design_combined.md#8ロギングとクエリ可視化)
+
+This sample corresponds to [docs_configuration_reference.md](../../docs/docs_configuration_reference.md).

--- a/examples/configuration-mapping/appsettings.Development.json
+++ b/examples/configuration-mapping/appsettings.Development.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Kafka.Ksql.Linq.Serialization": "Debug",
+      "Kafka.Ksql.Linq.Messaging": "Information",
+      "Kafka.Ksql.Linq.Query": "Debug"
+    }
+  }
+}

--- a/examples/configuration-mapping/appsettings.Production.json
+++ b/examples/configuration-mapping/appsettings.Production.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Kafka.Ksql.Linq.Serialization": "Warning",
+      "Kafka.Ksql.Linq.Messaging": "Warning",
+      "Kafka.Ksql.Linq.Query": "None"
+    }
+  }
+}

--- a/examples/configuration-mapping/appsettings.json
+++ b/examples/configuration-mapping/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Kafka.Ksql.Linq.Query": "Debug"
+    }
+  },
+  "KsqlDsl": {
+    "Common": {
+      "BootstrapServers": "localhost:9092",
+      "ClientId": "config-sample-app"
+    },
+    "SchemaRegistry": {
+      "Url": "http://localhost:8085"
+    }
+  }
+}

--- a/examples/configuration-mapping/docker-compose.yml
+++ b/examples/configuration-mapping/docker-compose.yml
@@ -1,0 +1,55 @@
+version: '3.7'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.3
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:7.4.3
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:9093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+    healthcheck:
+      test: ["CMD", "kafka-topics", "--bootstrap-server", "localhost:9092", "--list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  ksqldb-server:
+    image: confluentinc/ksqldb-server:0.29.0
+    depends_on:
+      kafka:
+        condition: service_healthy
+    ports:
+      - "8088:8088"
+    environment:
+      KSQL_CONFIG_DIR: "/etc/ksql"
+      KSQL_BOOTSTRAP_SERVERS: "kafka:9092"
+      KSQL_LISTENERS: "http://0.0.0.0:8088"
+      KSQL_KSQL_SERVICE_ID: "ksql_service_1"
+      KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
+      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
+      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
+
+  ksqldb-cli:
+    image: confluentinc/ksqldb-cli:0.29.0
+    depends_on:
+      - ksqldb-server
+    entrypoint: /bin/sh
+    tty: true

--- a/examples/error-handling-dlq/ErrorHandlingDlq.csproj
+++ b/examples/error-handling-dlq/ErrorHandlingDlq.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Kafka.Ksql.Linq.csproj" />
+  </ItemGroup>
+</Project>

--- a/examples/error-handling-dlq/Program.cs
+++ b/examples/error-handling-dlq/Program.cs
@@ -1,0 +1,62 @@
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+[Topic("orders")]
+public class Order
+{
+    [Key]
+    public int Id { get; set; }
+
+    [DecimalPrecision(18, 2)]
+    public decimal Amount { get; set; }
+}
+
+public class OrderContext : KsqlContext
+{
+    protected override void OnModelCreating(IModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Order>();
+    }
+}
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var context = KsqlContextBuilder.Create()
+            .UseConfiguration(configuration)
+            .UseSchemaRegistry(configuration["KsqlDsl:SchemaRegistry:Url"]!)
+            .EnableLogging(LoggerFactory.Create(builder => builder.AddConsole()))
+            .BuildContext<OrderContext>();
+
+        var order = new Order
+        {
+            Id = Random.Shared.Next(),
+            Amount = -42.5m
+        };
+
+        await context.Set<Order>().AddAsync(order);
+        await Task.Delay(500);
+
+        await context.Set<Order>()
+            .OnError(ErrorAction.DLQ)
+            .WithRetry(3)
+            .ForEachAsync(o =>
+            {
+                if (o.Amount < 0)
+                {
+                    throw new InvalidOperationException("Amount cannot be negative");
+                }
+                Console.WriteLine($"Processed order {o.Id}: {o.Amount}");
+                return Task.CompletedTask;
+            });
+    }
+}

--- a/examples/error-handling-dlq/README.md
+++ b/examples/error-handling-dlq/README.md
@@ -1,0 +1,25 @@
+# Error Handling with DLQ Example
+
+`Program.cs` sends an invalid `Order` to demonstrate `.OnError(ErrorAction.DLQ)`
+and `.WithRetry(3)`. Records that fail processing are forwarded to the configured
+Dead Letter Queue after retries.
+
+This sample maps to
+[docs_advanced_rules.md](../../docs/docs_advanced_rules.md) section about
+`OnError` and retry strategies.
+
+## Prerequisites
+- .NET 8 SDK
+- Docker
+
+## Run Steps
+1. Start Kafka and ksqlDB:
+   ```bash
+   docker-compose up -d
+   ```
+2. Run the program:
+   ```bash
+   dotnet run --project .
+   ```
+
+Use `LogLevel: Debug` to observe the generated DSL queries in the console.

--- a/examples/error-handling-dlq/appsettings.json
+++ b/examples/error-handling-dlq/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Kafka.Ksql.Linq.Query": "Debug"
+    }
+  },
+  "KsqlDsl": {
+    "Common": {
+      "BootstrapServers": "localhost:9092",
+      "ClientId": "error-app"
+    },
+    "SchemaRegistry": {
+      "Url": "http://localhost:8085"
+    }
+  }
+}

--- a/examples/error-handling-dlq/docker-compose.yml
+++ b/examples/error-handling-dlq/docker-compose.yml
@@ -1,0 +1,55 @@
+version: '3.7'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.3
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:7.4.3
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:9093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+    healthcheck:
+      test: ["CMD", "kafka-topics", "--bootstrap-server", "localhost:9092", "--list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  ksqldb-server:
+    image: confluentinc/ksqldb-server:0.29.0
+    depends_on:
+      kafka:
+        condition: service_healthy
+    ports:
+      - "8088:8088"
+    environment:
+      KSQL_CONFIG_DIR: "/etc/ksql"
+      KSQL_BOOTSTRAP_SERVERS: "kafka:9092"
+      KSQL_LISTENERS: "http://0.0.0.0:8088"
+      KSQL_KSQL_SERVICE_ID: "ksql_service_1"
+      KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
+      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
+      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
+
+  ksqldb-cli:
+    image: confluentinc/ksqldb-cli:0.29.0
+    depends_on:
+      - ksqldb-server
+    entrypoint: /bin/sh
+    tty: true

--- a/examples/manual-commit/README.md
+++ b/examples/manual-commit/README.md
@@ -26,3 +26,4 @@ Successful processing calls `.CommitAsync()`; failures call `.NegativeAckAsync()
 - [手動コミット操作](../../docs/manual_commit.md)
 - [POCO属性設計](../../docs/oss_design_combined.md#3-poco属性ベースdsl設計ルール（fluent-apiの排除方針）)
 - [スキーマ初期化](../../docs/oss_design_combined.md#4-スキーマ構築と初期化手順（onmodelcreating）)
+\nSee the manual commit API in [api_reference.md](../../docs/api_reference.md).

--- a/examples/sqlserver-vs-kafka/Program.cs
+++ b/examples/sqlserver-vs-kafka/Program.cs
@@ -1,0 +1,59 @@
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+[Topic("sql-orders")]
+public class SqlOrder
+{
+    [Key]
+    public int Id { get; set; }
+
+    [AvroTimestamp]
+    public DateTime CreatedAt { get; set; }
+
+    public string Text { get; set; } = string.Empty;
+}
+
+public class SqlKafkaContext : KsqlContext
+{
+    protected override void OnModelCreating(IModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<SqlOrder>();
+    }
+}
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var context = KsqlContextBuilder.Create()
+            .UseConfiguration(configuration)
+            .UseSchemaRegistry(configuration["KsqlDsl:SchemaRegistry:Url"]!)
+            .EnableLogging(LoggerFactory.Create(builder => builder.AddConsole()))
+            .BuildContext<SqlKafkaContext>();
+
+        var message = new SqlOrder
+        {
+            Id = Random.Shared.Next(),
+            CreatedAt = DateTime.UtcNow,
+            Text = "Sync Sample"
+        };
+
+        await context.Set<SqlOrder>().AddAsync(message);
+        // wait briefly for message to be published
+        await Task.Delay(500);
+
+        await context.Set<SqlOrder>().ForEachAsync(m =>
+        {
+            Console.WriteLine($"Kafka received: {m.Text}");
+            return Task.CompletedTask;
+        });
+    }
+}

--- a/examples/sqlserver-vs-kafka/README.md
+++ b/examples/sqlserver-vs-kafka/README.md
@@ -1,0 +1,25 @@
+# SQL Server vs Kafka Example
+
+This sample mirrors a simple insert/select workflow familiar to SQL Server
+developers using the Kafka DSL. `SqlOrder` is written to a topic and then
+consumed back, illustrating the similarity between traditional SQL operations
+and the LINQ-based streaming approach.
+
+See [sqlserver-to-kafka-guide.md](../../docs/sqlserver-to-kafka-guide.md) for the
+related migration guide.
+
+## Prerequisites
+- .NET 8 SDK
+- Docker
+
+## Run Steps
+1. Launch Kafka and ksqlDB:
+   ```bash
+   docker-compose up -d
+   ```
+2. Execute the sample:
+   ```bash
+   dotnet run --project .
+   ```
+
+Enable debug logging to view the translated queries.

--- a/examples/sqlserver-vs-kafka/SqlserverVsKafka.csproj
+++ b/examples/sqlserver-vs-kafka/SqlserverVsKafka.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Kafka.Ksql.Linq.csproj" />
+  </ItemGroup>
+</Project>

--- a/examples/sqlserver-vs-kafka/appsettings.json
+++ b/examples/sqlserver-vs-kafka/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Kafka.Ksql.Linq.Query": "Debug"
+    }
+  },
+  "KsqlDsl": {
+    "Common": {
+      "BootstrapServers": "localhost:9092",
+      "ClientId": "hello-app"
+    },
+    "SchemaRegistry": {
+      "Url": "http://localhost:8085"
+    }
+  }
+}

--- a/examples/sqlserver-vs-kafka/docker-compose.yml
+++ b/examples/sqlserver-vs-kafka/docker-compose.yml
@@ -1,0 +1,55 @@
+version: '3.7'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.3
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:7.4.3
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:9093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+    healthcheck:
+      test: ["CMD", "kafka-topics", "--bootstrap-server", "localhost:9092", "--list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  ksqldb-server:
+    image: confluentinc/ksqldb-server:0.29.0
+    depends_on:
+      kafka:
+        condition: service_healthy
+    ports:
+      - "8088:8088"
+    environment:
+      KSQL_CONFIG_DIR: "/etc/ksql"
+      KSQL_BOOTSTRAP_SERVERS: "kafka:9092"
+      KSQL_LISTENERS: "http://0.0.0.0:8088"
+      KSQL_KSQL_SERVICE_ID: "ksql_service_1"
+      KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
+      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
+      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
+
+  ksqldb-cli:
+    image: confluentinc/ksqldb-cli:0.29.0
+    depends_on:
+      - ksqldb-server
+    entrypoint: /bin/sh
+    tty: true

--- a/examples/window-finalization/Program.cs
+++ b/examples/window-finalization/Program.cs
@@ -1,0 +1,66 @@
+using Kafka.Ksql.Linq.Application;
+using Kafka.Ksql.Linq.Core.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+using System.Linq;
+[Topic("sales")]
+public class Sale
+{
+    [Key]
+    public int Id { get; set; }
+
+    [AvroTimestamp]
+    public DateTime OccurredAt { get; set; }
+
+    [DecimalPrecision(18, 2)]
+    public decimal Amount { get; set; }
+}
+
+public class SalesContext : KsqlContext
+{
+    protected override void OnModelCreating(IModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Sale>();
+    }
+}
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var context = KsqlContextBuilder.Create()
+            .UseConfiguration(configuration)
+            .UseSchemaRegistry(configuration["KsqlDsl:SchemaRegistry:Url"]!)
+            .EnableLogging(LoggerFactory.Create(builder => builder.AddConsole()))
+            .BuildContext<SalesContext>();
+
+        var message = new Sale
+        {
+            Id = Random.Shared.Next(),
+            OccurredAt = DateTime.UtcNow,
+            Amount = 20m
+        };
+
+        await context.Set<Sale>().AddAsync(message);
+        // wait briefly for message to be published
+        await Task.Delay(500);
+
+        await context.Set<Sale>()
+            .Window(TumblingWindow.OfMinutes(1).EmitFinal())
+            .UseFinalized()
+            .GroupBy(_ => 1)
+            .Select(g => new { Total = g.Sum(s => s.Amount) })
+            .ForEachAsync(r =>
+            {
+                Console.WriteLine($"Window total: {r.Total}");
+                return Task.CompletedTask;
+            });
+    }
+}

--- a/examples/window-finalization/README.md
+++ b/examples/window-finalization/README.md
@@ -1,0 +1,24 @@
+# Window Finalization Example
+
+This sample demonstrates tumbling window aggregation with finalized results.
+`Program.cs` produces a `Sale` record and then queries a 1-minute window using
+`Window(...).UseFinalized()`.
+
+This example corresponds to the window processing description in
+[docs_advanced_rules.md](../../docs/docs_advanced_rules.md).
+
+## Prerequisites
+- .NET 8 SDK
+- Docker
+
+## Run Steps
+1. Start Kafka and ksqlDB:
+   ```bash
+   docker-compose up -d
+   ```
+2. Run the program:
+   ```bash
+   dotnet run --project .
+   ```
+
+Debug logging reveals the generated queries for troubleshooting.

--- a/examples/window-finalization/WindowFinalization.csproj
+++ b/examples/window-finalization/WindowFinalization.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/Kafka.Ksql.Linq.csproj" />
+  </ItemGroup>
+</Project>

--- a/examples/window-finalization/appsettings.json
+++ b/examples/window-finalization/appsettings.json
@@ -1,0 +1,17 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Kafka.Ksql.Linq.Query": "Debug"
+    }
+  },
+  "KsqlDsl": {
+    "Common": {
+      "BootstrapServers": "localhost:9092",
+      "ClientId": "hello-app"
+    },
+    "SchemaRegistry": {
+      "Url": "http://localhost:8085"
+    }
+  }
+}

--- a/examples/window-finalization/docker-compose.yml
+++ b/examples/window-finalization/docker-compose.yml
@@ -1,0 +1,55 @@
+version: '3.7'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.4.3
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: confluentinc/cp-kafka:7.4.3
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:9093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+    healthcheck:
+      test: ["CMD", "kafka-topics", "--bootstrap-server", "localhost:9092", "--list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  ksqldb-server:
+    image: confluentinc/ksqldb-server:0.29.0
+    depends_on:
+      kafka:
+        condition: service_healthy
+    ports:
+      - "8088:8088"
+    environment:
+      KSQL_CONFIG_DIR: "/etc/ksql"
+      KSQL_BOOTSTRAP_SERVERS: "kafka:9092"
+      KSQL_LISTENERS: "http://0.0.0.0:8088"
+      KSQL_KSQL_SERVICE_ID: "ksql_service_1"
+      KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET: "earliest"
+      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
+      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
+
+  ksqldb-cli:
+    image: confluentinc/ksqldb-cli:0.29.0
+    depends_on:
+      - ksqldb-server
+    entrypoint: /bin/sh
+    tty: true


### PR DESCRIPTION
## Summary
- add basic produce/consume example and docs reference
- show window finalization with tumbling windows
- demonstrate DLQ error handling with retries
- illustrate configuration mapping options
- add SQL Server vs Kafka sample
- showcase API patterns in one example
- update manual commit docs link

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868db2ee2c08327b557e733fa1a4d8e