### PR TITLE
Restrict query DSL usage to model creation

### DIFF
--- a/src/Core/Context/KafkaContextCore.cs
+++ b/src/Core/Context/KafkaContextCore.cs
@@ -83,7 +83,10 @@ public abstract class KafkaContextCore : IKsqlContext
     protected void ConfigureModel()
     {
         var modelBuilder = new ModelBuilder(Options.ValidationMode);
-        OnModelCreating(modelBuilder);
+        using (ModelCreationScope.Enter())
+        {
+            OnModelCreating(modelBuilder);
+        }
         ApplyModelBuilderSettings(modelBuilder);
     }
 

--- a/src/Core/Context/ModelCreationScope.cs
+++ b/src/Core/Context/ModelCreationScope.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading;
+
+namespace Kafka.Ksql.Linq.Core.Context;
+
+/// <summary>
+/// Provides a scope that marks execution as part of OnModelCreating.
+/// Query builder APIs like Where/GroupBy/Select are allowed only within this scope.
+/// </summary>
+internal static class ModelCreationScope
+{
+    private static readonly AsyncLocal<bool> _flag = new();
+
+    public static bool IsActive => _flag.Value;
+
+    public static IDisposable Enter()
+    {
+        _flag.Value = true;
+        return new Scope();
+    }
+
+    public static void EnsureActive(string apiName)
+    {
+        if (!IsActive)
+        {
+            throw new InvalidOperationException($"{apiName} のクエリ定義はOnModelCreating専用です。");
+        }
+    }
+
+    private sealed class Scope : IDisposable
+    {
+        public void Dispose()
+        {
+            _flag.Value = false;
+        }
+    }
+}

--- a/src/Query/Pipeline/DDLQueryGenerator.cs
+++ b/src/Query/Pipeline/DDLQueryGenerator.cs
@@ -2,6 +2,7 @@ using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Query.Abstractions;
 using Kafka.Ksql.Linq.Query.Builders;
 using Kafka.Ksql.Linq.Query.Builders.Common;
+using Kafka.Ksql.Linq.Core.Context;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -92,6 +93,7 @@ internal class DDLQueryGenerator : GeneratorBase, IDDLQueryGenerator
     /// </summary>
     public string GenerateCreateStreamAs(string streamName, string baseObject, Expression linqExpression)
     {
+        ModelCreationScope.EnsureActive("Where/GroupBy/Select");
         try
         {
             var context = new QueryAssemblyContext(baseObject, false); // Push Query
@@ -114,6 +116,7 @@ internal class DDLQueryGenerator : GeneratorBase, IDDLQueryGenerator
     /// </summary>
     public string GenerateCreateTableAs(string tableName, string baseObject, Expression linqExpression)
     {
+        ModelCreationScope.EnsureActive("Where/GroupBy/Select");
         try
         {
             var context = new QueryAssemblyContext(baseObject, false); // Push Query

--- a/src/Query/Pipeline/DMLQueryGenerator.cs
+++ b/src/Query/Pipeline/DMLQueryGenerator.cs
@@ -1,6 +1,7 @@
 using Kafka.Ksql.Linq.Query.Abstractions;
 using Kafka.Ksql.Linq.Query.Builders;
 using Kafka.Ksql.Linq.Query.Builders.Common;
+using Kafka.Ksql.Linq.Core.Context;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -105,6 +106,7 @@ internal class DMLQueryGenerator : GeneratorBase, IDMLQueryGenerator
     /// </summary>
     public string GenerateAggregateQuery(string objectName, Expression aggregateExpression)
     {
+        ModelCreationScope.EnsureActive("Where/GroupBy/Select");
         try
         {
             var context = new QueryAssemblyContext(objectName, true); // Aggregates default to pull query
@@ -132,6 +134,7 @@ internal class DMLQueryGenerator : GeneratorBase, IDMLQueryGenerator
     /// </summary>
     public string GenerateLinqQuery(string objectName, Expression linqExpression, bool isPullQuery = false)
     {
+        ModelCreationScope.EnsureActive("Where/GroupBy/Select");
         try
         {
             var context = new QueryAssemblyContext(objectName, isPullQuery);

--- a/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
+++ b/tests/Query/Pipeline/DDLQueryGeneratorTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using Kafka.Ksql.Linq.Core.Abstractions;
 using Kafka.Ksql.Linq.Query.Pipeline;
+using Kafka.Ksql.Linq.Core.Context;
 using Xunit;
 
 namespace Kafka.Ksql.Linq.Tests.Query.Pipeline;
@@ -38,7 +39,11 @@ public class DDLQueryGeneratorTests
                          .GroupBy(e => e.Type)
                          .Select(g => new { g.Key, Count = g.Count() });
         var generator = new DDLQueryGenerator();
-        var query = generator.GenerateCreateTableAs("t1", "Base", expr.Expression);
+        string query;
+        using (ModelCreationScope.Enter())
+        {
+            query = generator.GenerateCreateTableAs("t1", "Base", expr.Expression);
+        }
         Assert.Contains("CREATE TABLE t1 AS SELECT", query);
         Assert.Contains("FROM Base", query);
         Assert.Contains("WHERE (IsActive = true)", query);


### PR DESCRIPTION
## Summary
- add `ModelCreationScope` to track `OnModelCreating` execution
- guard query generators so Where/GroupBy/Select chains are only allowed in this scope
- update context to enable the scope
- adjust unit tests to enter the scope when using query builders

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686912e46ecc8327841675bbb6e42969